### PR TITLE
Ask YouTube for a PO token once it starts refusing us

### DIFF
--- a/.github/workflows/build-pot-payload.yml
+++ b/.github/workflows/build-pot-payload.yml
@@ -1,0 +1,255 @@
+# Builds the PO token payload and puts it on the `binaries` release, beside
+# ffmpeg and deno.
+#
+# Run this by hand, and rarely: once per provider version. bgutil is on 1.3.2
+# today, so the next time this runs is whenever that number changes. It is not
+# part of a release build - the payload is fetched at runtime by the handful of
+# installs YouTube has refused, not bundled into the installer everyone gets.
+#
+# Upstream publishes only the 8 KB plugin, and the half that actually mints
+# tokens is a node project that has to be installed. It carries `canvas`, which
+# is native code, so the tree stops being portable and each platform needs its
+# own build - which is the only reason this is CI rather than a manual upload.
+#
+# Defaults to a dry run: it builds, verifies and reports without touching the
+# release. Tick `publish` when the numbers look right.
+name: Build PO token payload
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'bgutil-ytdlp-pot-provider version (a git tag upstream)'
+        required: true
+        default: '1.3.2'
+      publish:
+        description: 'Upload to the binaries release (leave off for a dry run)'
+        type: boolean
+        default: false
+
+concurrency:
+  group: cliply-pot-payload
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # the two platforms build-release.yml actually ships
+          - os: windows-latest
+            asset: win32-x64
+            deno: deno.exe
+          - os: macos-14
+            asset: darwin-arm64
+            deno: deno
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      # only for our own archive.js, which the verify step reads the finished
+      # zip with. no npm install - it uses node builtins alone
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch the provider source
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fL --retry 3 --retry-delay 2 -o provider.tar.gz \
+            "https://github.com/Brainicism/bgutil-ytdlp-pot-provider/archive/refs/tags/${{ inputs.version }}.tar.gz"
+          tar -xzf provider.tar.gz
+          test -d "bgutil-ytdlp-pot-provider-${{ inputs.version }}"
+
+      - name: Install the generator
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd "bgutil-ytdlp-pot-provider-${{ inputs.version }}/server"
+
+          # npm rather than deno on purpose: a deno-installed node_modules is
+          # full of symlinks, and our own zip reader refuses non-regular
+          # entries. this layout has none once .bin is gone
+          npm install --omit=dev --no-audit --no-fund
+
+          # canvas is an optional peer of jsdom, so it needs asking for by
+          # name. botguard probes canvas as a fingerprinting signal, so the
+          # emulation is more faithful with it than without
+          npm install canvas --no-audit --no-fund
+
+          # the only symlinks npm creates, and the deno-run generator never
+          # calls them
+          rm -rf node_modules/.bin
+
+      - name: Assemble the payload
+        shell: bash
+        run: |
+          set -euo pipefail
+          src="bgutil-ytdlp-pot-provider-${{ inputs.version }}"
+          mkdir -p payload/plugin payload/server
+
+          # the plugin stays zipped - yt-dlp reads --plugin-dirs entries
+          # straight out of an archive, so this half is one 8 KB file.
+          #
+          # git bash on the windows runner ships no `zip`, so 7-zip stands in
+          # there. both write deflate, which is what our own reader understands
+          cd "$src/plugin"
+          out="$GITHUB_WORKSPACE/payload/plugin/bgutil-plugin.zip"
+          if command -v zip >/dev/null 2>&1; then
+            zip -q -r -9 "$out" yt_dlp_plugins
+          else
+            7z a -tzip -mx=9 "$out" yt_dlp_plugins >/dev/null
+          fi
+          cd "$GITHUB_WORKSPACE"
+
+          cp -R "$src/server/src" "$src/server/node_modules" payload/server/
+          cp "$src/server/package.json" "$src/server/deno.json" payload/server/
+
+          # the two directories the engine's getPotPaths() insists on
+          test -d payload/plugin && test -d payload/server
+
+      # the generator runs on deno, so deno is what has to be able to load
+      # canvas. a native module that the runtime cannot open is dead weight,
+      # and this is the only place that difference is visible
+      - name: Check that Deno can actually load canvas
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fL --retry 3 -o deno-bin \
+            "https://github.com/${{ github.repository }}/releases/download/binaries/${{ matrix.deno }}"
+          chmod +x deno-bin
+          cat > payload/server/canvas-check.mjs <<'JS'
+          import { createRequire } from "node:module"
+          const require = createRequire(import.meta.url)
+          const canvas = require("canvas")
+          const surface = canvas.createCanvas(32, 32)
+          const ctx = surface.getContext("2d")
+          ctx.fillRect(0, 0, 8, 8)
+          console.log("canvas loaded under deno:", surface.toDataURL().slice(0, 30))
+          JS
+          "$GITHUB_WORKSPACE/deno-bin" run --allow-all payload/server/canvas-check.mjs
+          rm payload/server/canvas-check.mjs
+
+      - name: Zip it
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd payload
+          out="../pot-${{ inputs.version }}-${{ matrix.asset }}.zip"
+          # fastest compression: this is ~9k files of javascript and the wall
+          # clock of a user's one-off download is not worth another minute here
+          if command -v zip >/dev/null 2>&1; then
+            zip -q -r -1 "$out" plugin server
+          else
+            7z a -tzip -mx=1 "$out" plugin server >/dev/null
+          fi
+
+      # the payload is unpacked on the user's machine by our own hand-rolled
+      # reader, not by the system's. so the thing that has to be able to open
+      # it is the thing that opens it, and that is checked here rather than
+      # discovered by a blocked user whose fetch silently achieved nothing
+      - name: Verify with the reader that will have to open it
+        shell: bash
+        env:
+          ZIP: pot-${{ inputs.version }}-${{ matrix.asset }}.zip
+        run: |
+          node -e '
+            const fs = require("fs")
+            const { extractZip, sha256File } = require("./src/main/utils/archive")
+            ;(async () => {
+              await extractZip(process.env.ZIP, "verify-out")
+              for (const half of ["plugin", "server"]) {
+                if (!fs.statSync(`verify-out/${half}`).isDirectory()) {
+                  throw new Error(`${half}/ is missing from the payload`)
+                }
+              }
+              if (!fs.existsSync("verify-out/plugin/bgutil-plugin.zip")) {
+                throw new Error("the plugin zip is missing")
+              }
+              const files = fs.readdirSync("verify-out/server")
+              console.log("server holds:", files.join(", "))
+              console.log("sha256:", await sha256File(process.env.ZIP))
+            })().catch((error) => {
+              console.error(error.message)
+              process.exit(1)
+            })
+          '
+          rm -rf verify-out
+
+      - name: Report
+        shell: bash
+        env:
+          ZIP: pot-${{ inputs.version }}-${{ matrix.asset }}.zip
+        run: |
+          set -euo pipefail
+          if command -v sha256sum >/dev/null; then
+            digest=$(sha256sum "$ZIP" | cut -d' ' -f1)
+          else
+            digest=$(shasum -a 256 "$ZIP" | cut -d' ' -f1)
+          fi
+          size=$(node -e "console.log((require('fs').statSync(process.env.ZIP).size/1048576).toFixed(1))")
+          echo "$digest" > "$ZIP.sha256"
+          {
+            echo "### ${{ matrix.asset }}"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| asset | \`$ZIP\` |"
+            echo "| size | ${size} MB |"
+            echo "| sha256 | \`$digest\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: pot-${{ matrix.asset }}
+          path: |
+            pot-*.zip
+            pot-*.zip.sha256
+
+  publish:
+    needs: build
+    if: ${{ inputs.publish }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: payloads
+          merge-multiple: true
+
+      # the same tag ffmpeg and deno already live on. --clobber so a rebuild of
+      # the same version replaces rather than fails
+      - name: Upload to the binaries release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh release upload binaries payloads/pot-*.zip \
+            --repo "${{ github.repository }}" --clobber
+
+      # pinned in code rather than fetched beside the download: a checksum
+      # served from the same host as the bytes it vouches for only proves the
+      # two agree. this prints the block to paste into pot-installer.js
+      - name: What to paste into POT_CHECKSUMS
+        run: |
+          set -euo pipefail
+          {
+            echo "### Pin these in \`src/main/services/pot-installer.js\`"
+            echo ""
+            echo '```js'
+            echo 'const POT_CHECKSUMS = {'
+            for sum in payloads/*.sha256; do
+              asset=$(basename "$sum" .sha256)
+              echo "  \"$asset\":"
+              echo "    \"$(cat "$sum")\","
+            done
+            echo '}'
+            echo '```'
+            echo ""
+            echo "Until they are pinned, the installer declines every fetch."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -325,7 +325,7 @@
   "bugs": {
     "url": "https://github.com/Cliply/Cliply/issues"
   },
-  "license": "MIT",
+  "license": "GPL-3.0-only",
   "jest": {
     "testEnvironment": "node",
     "testMatch": [

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -12,6 +12,7 @@ const isDev = process.env.NODE_ENV === "development"
 const CookieManager = require("./services/cookie-manager")
 const { YtdlpEngine } = require("./services/ytdlp-engine")
 const { YtdlpUpdater } = require("./services/ytdlp-updater")
+const { PotInstaller } = require("./services/pot-installer")
 const { SettingsStore } = require("./services/settings-store")
 const { Analytics } = require("./services/analytics")
 const IPCHandlers = require("./ipc-handlers")
@@ -164,6 +165,23 @@ class CliplyApp {
         engine: this.services.ytdlpEngine
       })
 
+      // an install that was refused before is still refused now - the block
+      // follows the connection, not the session - so the escalation is read
+      // back before the first operation rather than rediscovered by failing
+      // again. the store expires it on its own after a week, so a stale `true`
+      // never survives here as one
+      this.services.ytdlpEngine.setPotEnabled(
+        await this.services.settingsStore.isPotEnabled()
+      )
+
+      // nothing is fetched here - it is built now and asked for later, by the
+      // first refusal that finds the payload missing
+      this.services.potInstaller = new PotInstaller({
+        engine: this.services.ytdlpEngine
+      })
+
+      this.notePotEnvironment()
+
       // make sure userData holds a runnable binary before anything needs it
       const seeded = await this.services.ytdlpUpdater.seed()
       console.log("yt-dlp engine:", this.services.ytdlpEngine.getBinaryPath(), seeded)
@@ -200,6 +218,21 @@ class CliplyApp {
       console.error("Service initialization failed:", error)
       throw error
     }
+  }
+
+  /**
+   * tell analytics what this install could mint a PO token with
+   *
+   * both answers are read from the engine rather than passed in, because the
+   * engine is what actually decides: it is the same two lookups buildCommonArgs
+   * gates the flags on, so what is reported is what was used rather than a
+   * second opinion about it.
+   */
+  notePotEnvironment() {
+    this.services.analytics.setPotEnvironment({
+      denoPresent: Boolean(this.services.ytdlpEngine.getDenoPath()),
+      potProvider: Boolean(this.services.ytdlpEngine.getPotPaths())
+    })
   }
 
   /**

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -139,6 +139,11 @@ class IPCHandlers {
     // one source of truth for the download folder, shared with the settings ipc
     this.settings = services.settingsStore || new SettingsStore()
 
+    // fetches the PO token payload the first time an install is refused.
+    // absent in a build that never constructed one, and a refusal still
+    // escalates without it - there is just nothing yet to escalate with
+    this.potInstaller = services.potInstaller || null
+
     // drives engine downloads and forwards their progress to the renderer
     this.runner = new DownloadRunner({
       engine: this.engine,
@@ -329,6 +334,86 @@ class IPCHandlers {
       success: Boolean(imported),
       has_youtube_cookies: Boolean(this.cookieManager.hasValidCookies())
     })
+  }
+
+  /**
+   * escalate to a PO token, because this install has just been refused
+   *
+   * yt-dlp's advice is to run the default clients until they stop working and
+   * only then reach for a token provider. this is the "stop working" - the one
+   * signal that says the default clients are done for this connection, so it is
+   * the only thing that turns the escalation on. RATE_LIMITED deliberately does
+   * not: the audit found throttling landing mostly on installs that were never
+   * blocked at all, which makes it a reading of the user's network rather than
+   * of youtube's door policy.
+   *
+   * both halves are set, because they answer different questions. the engine
+   * field is what the *next* operation reads, so a user who was refused once
+   * does not have to restart the app to benefit; the settings write is what a
+   * restart reads back, so they do not have to be refused again to re-learn it.
+   *
+   * re-stamped on every refusal rather than written once. the stored timestamp
+   * expires the escalation after a week, and refreshing it here is what makes
+   * that window mean "a week since youtube last turned us away" instead of "a
+   * week since the first time it ever did".
+   *
+   * @param {string} category - what the taxonomy made of the failure
+   * @returns {boolean} whether a payload is being fetched because of this
+   */
+  noteRefusal(category) {
+    if (category !== ERROR_CATEGORIES.BOT_DETECTION) return false
+
+    this.engine.setPotEnabled(true)
+
+    // fired, never awaited: the operation that failed is already answering the
+    // user, and it must not wait on our disk to do it. a write that does not
+    // land costs one more refusal after the next launch, which is the same
+    // failure this install just had - not a new way to break
+    Promise.resolve(this.settings.setPotEnabled(true))
+      .then((result) => {
+        if (result && result.success === false) {
+          console.warn(`could not persist the PO token escalation: ${result.error}`)
+        }
+      })
+      .catch((error) => {
+        console.warn(
+          "could not persist the PO token escalation:",
+          describeError(error)
+        )
+      })
+
+    // the flag alone escalates nothing: the engine only emits the flags when
+    // the payload is actually on disk, so this is what makes the escalation
+    // real. also fired rather than awaited - a ~70 mb download is not
+    // something to hold a failed request open for
+    // nothing published for this platform means nothing to fetch, and the
+    // sentence we would otherwise add to the error promises a fix that is
+    // never coming. asked before starting rather than after, because the user
+    // is told now and the download answers later
+    if (!this.potInstaller || !this.potInstaller.canInstall()) return false
+
+    const needed = !this.engine.getPotPaths()
+
+    this.potInstaller
+      .ensureInstalled()
+      .then((result) => {
+        // the payload arrives partway through a session, so the super property
+        // that reports whether this install has one is not fixed at startup.
+        // left stale it would read as "the download never works"
+        if (result && result.installed && this.analytics) {
+          this.analytics.setPotEnvironment({
+            denoPresent: Boolean(this.engine.getDenoPath()),
+            potProvider: Boolean(this.engine.getPotPaths())
+          })
+        }
+      })
+      .catch((error) => {
+        // ensureInstalled already keeps a never-rejects promise; this is here so
+        // that a broken collaborator cannot surface as an unhandled rejection
+        console.warn("PO token payload install failed:", describeError(error))
+      })
+
+    return needed
   }
 
   // audit logging
@@ -532,13 +617,40 @@ class IPCHandlers {
       return this.createSuccess(videoInfo)
     } catch (error) {
       console.error("Info extraction failed:", error.message)
+
+      const { category } = classify(error, ERROR_STAGES.FETCH_INFO)
+
+      // the metadata fetch is the first thing a blocked install fails at, so
+      // this is usually where the refusal is discovered
+      const fetching = this.noteRefusal(category)
+
+      /**
+       * the only thing the user is told about the download, and it is told
+       * here because this is the one error surface that actually reaches them:
+       * `suggestion` is carried all the way to the renderer's DownloadError and
+       * then never rendered by anything.
+       *
+       * a sentence rather than a progress bar. the work is not something they
+       * asked for or can act on, and the honest report of it is short: a fix is
+       * coming, try again shortly. saying nothing at all would leave a user
+       * retrying into the same wall with no idea it was about to stop - and a
+       * bare percentage would explain even less than silence.
+       *
+       * only when a fetch really did start. an install that already has the
+       * payload and is still being refused has nothing to wait for, and
+       * promising it would be a lie the second time.
+       */
+      const message = error.message || "Failed to get media information"
+
       return this.createError(
-        error.message || "Failed to get media information",
+        fetching
+          ? `${message} Setting up a fix in the background - try again in a minute.`
+          : message,
         error.suggestion || "Please check the URL and try again",
         error.code || "GENERAL_ERROR",
         {
           details: error.details || undefined,
-          category: classify(error, ERROR_STAGES.FETCH_INFO).category
+          category
         }
       )
     }
@@ -826,9 +938,18 @@ class IPCHandlers {
   // knows the download id before the first progress event reaches it
   startDownload(options) {
     setImmediate(() => {
-      this.runner.run(options).catch((error) => {
-        console.error("download runner crashed:", error.message)
-      })
+      this.runner
+        .run(options)
+        .then((result) => {
+          // the download half of the refusal check. a cancel is not a refusal,
+          // and it settles through here wearing the same `success: false`
+          if (result && !result.success && !result.cancelled) {
+            this.noteRefusal(classify(result.error, ERROR_STAGES.DOWNLOAD).category)
+          }
+        })
+        .catch((error) => {
+          console.error("download runner crashed:", error.message)
+        })
     })
   }
 

--- a/src/main/services/analytics.js
+++ b/src/main/services/analytics.js
@@ -153,6 +153,19 @@ const PROPERTY_KINDS = {
   arch: "vocabulary",
   locale: "locale",
 
+  /**
+   * whether this install can mint a PO token at all, which is two separate
+   * questions: is there a js runtime to run the generator on, and is the
+   * payload actually installed. neither is answerable from a single event -
+   * they describe the machine, not the operation - and both have to ride every
+   * event to be joinable against the failures they explain.
+   *
+   * media_info_failed is the one that matters: a renderer event, raised by the
+   * half of the app that cannot see either of these facts.
+   */
+  deno_present: "bool",
+  pot_provider: "bool",
+
   // two values, both ours, listed in PROPERTY_VOCABULARIES - a closed kind,
   // which is what a build indicator should be: it exists so a dev session is
   // filterable rather than indistinguishable, and nothing about that needs a
@@ -1042,6 +1055,7 @@ class Analytics {
     this.superProperties = {}
     // kept apart from superProperties because init() rebuilds those wholesale
     this.engineVersion = null
+    this.potEnvironment = null
 
     /**
      * which toggle currently speaks for the user.
@@ -1104,6 +1118,12 @@ class Analytics {
         this.superProperties.engine_version = this.engineVersion
       }
 
+      // same reason as the engine version above: probed once, at startup, and
+      // this rebuild would otherwise drop it for the rest of the session
+      if (this.potEnvironment) {
+        Object.assign(this.superProperties, this.potEnvironment)
+      }
+
       this.client = this.createClient(
         APP_CONFIG.ANALYTICS_CONFIG.POSTHOG_KEY,
         APP_CONFIG.ANALYTICS_CONFIG.POSTHOG_HOST
@@ -1141,6 +1161,34 @@ class Analytics {
 
     this.engineVersion = checked.value
     this.superProperties.engine_version = checked.value
+  }
+
+  /**
+   * record what this install could mint a PO token with, if it had to
+   *
+   * both are facts about the machine rather than about any one operation, so
+   * they are super properties: they ride every event, and the one that matters
+   * most is media_info_failed, which the renderer raises and which therefore
+   * cannot know either of them first-hand.
+   *
+   * set again whenever the answer changes - the payload arrives by download
+   * partway through a session, so `pot_provider` is not fixed at startup the
+   * way the engine version is.
+   *
+   * validated rather than trusted, for the same reason setEngineVersion() is:
+   * capture() spreads super properties last, so anything landing here outranks
+   * even a validated caller value.
+   *
+   * @param {Object} environment - {denoPresent, potProvider}
+   */
+  setPotEnvironment({ denoPresent, potProvider } = {}) {
+    const checked = checkSuperProperties({
+      deno_present: Boolean(denoPresent),
+      pot_provider: Boolean(potProvider)
+    })
+
+    this.potEnvironment = checked
+    Object.assign(this.superProperties, checked)
   }
 
   /**

--- a/src/main/services/pot-installer.js
+++ b/src/main/services/pot-installer.js
@@ -1,0 +1,273 @@
+/**
+ * fetches the PO token payload into userData/pot, once, on demand
+ *
+ * only an install youtube has actually refused ever needs this, so it is not
+ * in the installer: the ~86% who are never blocked download nothing, and the
+ * ones who are pay for it at the moment it would help them. that is the same
+ * bargain the engine already makes with userData/engine, and it lands the same
+ * way - download, verify, unpack, atomic swap - through the same machinery.
+ *
+ * nothing here may ever fail an operation. the payload being absent is a state
+ * the engine already handles: getPotPaths() returns null, buildCommonArgs()
+ * omits the flags, and the user gets exactly today's behaviour. so every
+ * failure in this file resolves to a reason rather than throwing.
+ */
+
+const fsp = require("fs").promises
+const path = require("path")
+
+const { createHttpClient, swapIn, removeQuietly } = require("./ytdlp-updater")
+// the download digests as it streams, so there is nothing left to hash here
+const { extractZip } = require("../utils/archive")
+
+/**
+ * the payload version, pinned.
+ *
+ * the plugin and the generator it drives are version-locked to each other - a
+ * major mismatch is a hard refusal from the plugin - so they ship as one
+ * artifact and share one version. that makes the lock unbreakable rather than
+ * merely documented.
+ */
+const POT_VERSION = "1.3.2"
+
+// alongside ffmpeg and deno, on the release tag that already holds them
+const DEFAULT_BASE_URL =
+  "https://github.com/Cliply/Cliply/releases/download/binaries"
+
+/**
+ * sha-256 of each published payload, keyed by asset name.
+ *
+ * pinned here rather than fetched beside the download: a checksum served from
+ * the same place as the bytes it vouches for only proves the two agree. the
+ * payload version is pinned in this file anyway, so its digest costs nothing
+ * to pin next to it.
+ *
+ * an asset with no entry here is one nobody has published and digested yet,
+ * and it is refused rather than fetched - see checksumFor(). that is why this
+ * being empty is the correct state today: it makes the installer inert until
+ * the artifacts exist, instead of trusting whatever answers the url.
+ */
+const POT_CHECKSUMS = {}
+
+// the payload is a node_modules tree; a slow connection needs room for ~70 mb
+const INSTALL_TIMEOUT_MS = 10 * 60 * 1000
+
+// what a finished install leaves behind, so a later refresh can read the
+// version it is replacing without unpacking anything
+const VERSION_MARKER = ".pot-version.json"
+
+/**
+ * which payload this machine needs
+ *
+ * one artifact per platform and architecture, because the token generator's
+ * fake browser includes a native drawing engine - botguard probes canvas, so
+ * it is more faithful to ship it than to drop it, and shipping it means the
+ * tree stops being portable.
+ *
+ * @param {string} platform - process.platform
+ * @param {string} arch - process.arch
+ * @returns {string} asset name
+ */
+function payloadAssetFor(platform = process.platform, arch = process.arch) {
+  return `pot-${POT_VERSION}-${platform}-${arch}.zip`
+}
+
+/**
+ * the digest an asset must match, or null when we have not vouched for one
+ * @param {string} asset - asset name
+ * @returns {string|null} lowercase hex sha-256
+ */
+function checksumFor(asset) {
+  // the override exists so a payload can be staged and verified before it is
+  // published. it still has to match, so it is a different digest rather than
+  // no digest
+  const override = process.env.CLIPLY_POT_SHA256
+
+  if (override) {
+    return String(override).trim().toLowerCase()
+  }
+
+  return POT_CHECKSUMS[asset] || null
+}
+
+class PotInstaller {
+  /**
+   * @param {Object} options
+   * @param {Object} options.engine - the yt-dlp engine, for its userData path
+   * @param {Object} [options.http] - injected for tests
+   */
+  constructor({ engine, http = null } = {}) {
+    this.engine = engine
+    // built on the first download rather than here: one of these is
+    // constructed at every launch and the overwhelming majority never fetch
+    // anything at all
+    this.http = http
+    // the install in flight, so a user who retries three times while it runs
+    // starts one download rather than three onto the same directory
+    this.inFlight = null
+  }
+
+  getPotDir() {
+    return path.join(this.engine.getUserDataPath(), "pot")
+  }
+
+  /**
+   * whether there is a payload this machine could actually fetch
+   *
+   * the same question install() asks, answered without starting anything, so
+   * that a caller can find out before telling the user a fix is on its way. a
+   * platform nobody has published and digested a payload for gets no download
+   * and no promise of one - see POT_CHECKSUMS.
+   *
+   * @returns {boolean} true when a published, vouched-for payload exists
+   */
+  canInstall() {
+    return Boolean(checksumFor(payloadAssetFor()))
+  }
+
+  /**
+   * make sure the payload is installed, fetching it if it is not
+   *
+   * safe to call on every refusal: an install that is already there is
+   * answered without touching the network, and one already running is joined
+   * rather than started again. that idempotence is also what a later refresh
+   * pass needs, so it can call this rather than grow its own copy.
+   *
+   * @returns {Promise<Object>} {installed, reason} - never rejects
+   */
+  ensureInstalled() {
+    if (this.inFlight) {
+      return this.inFlight
+    }
+
+    // present already: the engine finds the payload by looking for both halves
+    // of it, so its answer is the one that decides this
+    if (this.engine.getPotPaths()) {
+      return Promise.resolve({ installed: true, reason: "already-installed" })
+    }
+
+    this.inFlight = this.install()
+      .catch((error) => {
+        // the contract for every caller: a payload that could not be fetched
+        // leaves the app exactly as it was, so this is reported and swallowed
+        console.warn("PO token payload install failed:", error.message)
+        return { installed: false, reason: "install-failed", error: error.message }
+      })
+      .finally(() => {
+        this.inFlight = null
+      })
+
+    return this.inFlight
+  }
+
+  /**
+   * download, verify, unpack and swap the payload into place
+   * @returns {Promise<Object>} {installed, reason}
+   */
+  async install() {
+    const asset = payloadAssetFor()
+    const expected = checksumFor(asset)
+
+    if (!expected) {
+      // nothing is published for this platform yet, or nobody has vouched for
+      // what is. either way there is no version of this worth running
+      console.warn(`no PO token payload is published for ${asset}`)
+      return { installed: false, reason: "no-payload-published" }
+    }
+
+    const potDir = this.getPotDir()
+    const parent = path.dirname(potDir)
+    const workDir = path.join(parent, `.pot-download-${POT_VERSION}`)
+    const stagingDir = path.join(parent, `.pot-staging-${POT_VERSION}`)
+
+    const controller = new AbortController()
+    const timeout = setTimeout(() => {
+      console.warn("PO token payload download timed out, aborting")
+      controller.abort()
+    }, INSTALL_TIMEOUT_MS)
+
+    if (typeof timeout.unref === "function") {
+      timeout.unref()
+    }
+
+    try {
+      // a previous attempt that died mid-flight leaves both of these behind,
+      // and reusing either would install whatever it managed to write
+      await removeQuietly(workDir)
+      await removeQuietly(stagingDir)
+      await fsp.mkdir(workDir, { recursive: true })
+
+      const base = process.env.CLIPLY_POT_BASE_URL || DEFAULT_BASE_URL
+      const zipPath = path.join(workDir, asset)
+      const signal = controller.signal
+
+      if (!this.http) {
+        this.http = createHttpClient()
+      }
+
+      const digest = await this.http.download(`${base}/${asset}`, zipPath, {
+        signal
+      })
+
+      if (digest !== expected) {
+        console.warn(`PO token payload checksum mismatch: ${digest} != ${expected}`)
+        return { installed: false, reason: "checksum-mismatch" }
+      }
+
+      await extractZip(zipPath, stagingDir, { signal })
+
+      // both halves or nothing. the engine treats a payload with only one of
+      // them as absent, so an archive that unpacked to something else would
+      // otherwise install silently and never be used
+      if (!(await hasBothHalves(stagingDir))) {
+        return { installed: false, reason: "payload-layout-unexpected" }
+      }
+
+      await writeVersionMarker(stagingDir, asset)
+      await swapIn(stagingDir, potDir)
+
+      console.log(`installed the PO token payload (${asset})`)
+      return { installed: true, reason: "installed" }
+    } finally {
+      clearTimeout(timeout)
+      // the zip is never needed again, and staging only survives as potDir
+      await removeQuietly(workDir)
+      await removeQuietly(stagingDir)
+    }
+  }
+}
+
+// the two directories the engine's getPotPaths() insists on
+async function hasBothHalves(root) {
+  for (const half of ["plugin", "server"]) {
+    try {
+      const stats = await fsp.stat(path.join(root, half))
+      if (!stats.isDirectory()) return false
+    } catch {
+      return false
+    }
+  }
+
+  return true
+}
+
+/**
+ * record what was installed, for whoever has to replace it later
+ *
+ * written into the staging directory rather than beside it, so it moves into
+ * place with the payload it describes and cannot outlive it
+ */
+async function writeVersionMarker(stagingDir, asset) {
+  await fsp.writeFile(
+    path.join(stagingDir, VERSION_MARKER),
+    JSON.stringify({ version: POT_VERSION, asset }, null, 2),
+    "utf8"
+  )
+}
+
+module.exports = {
+  PotInstaller,
+  payloadAssetFor,
+  POT_VERSION,
+  VERSION_MARKER
+}

--- a/src/main/services/settings-store.js
+++ b/src/main/services/settings-store.js
@@ -18,6 +18,9 @@ const { APP_CONFIG } = require("../utils/constants")
 const SETTINGS_DIR = path.join(os.homedir(), ".config", "app-data-7c4f")
 const SETTINGS_FILE = path.join(SETTINGS_DIR, "settings.json")
 
+// how long a refusal keeps the PO token escalation on - see isPotEnabled()
+const POT_ESCALATION_TTL_MS = 7 * 24 * 60 * 60 * 1000
+
 /**
  * the layout crypto.randomUUID() produces, which is the only thing the
  * install id field has ever held.
@@ -338,15 +341,44 @@ class SettingsStore {
    * off by default on purpose: the answer for an install nobody has blocked is
    * "no", and that is also the answer when the settings file cannot be read.
    *
+   * the escalation expires because the blocks do. a quarter of the installs
+   * that were refused went on to succeed without any change from us, which
+   * means the block sits on the connection and lifts on its own - so a flag
+   * set once and kept forever would charge those users a token mint per video
+   * for the rest of the install's life to solve a problem they no longer have.
+   * a refusal after the window simply re-arms it, at the cost of the one failed
+   * request that already told us.
+   *
+   * a stamp we cannot read is treated as expired rather than as forever, which
+   * is the same direction as every other default here: the escalation has to be
+   * earned, and re-earning it costs one request.
+   *
    * @returns {Promise<boolean>} true once this install has been refused
    */
   async isPotEnabled() {
     const settings = await this.readAll()
-    return settings.pot_enabled === true
+
+    if (settings.pot_enabled !== true) {
+      return false
+    }
+
+    const setAt = settings.pot_enabled_at
+
+    if (!Number.isFinite(setAt)) {
+      return false
+    }
+
+    // a stamp in the future is left alone rather than expired: that is a clock
+    // that moved, and punishing the user for it means blocking them again
+    return Date.now() - setAt < POT_ESCALATION_TTL_MS
   }
 
   /**
    * remember that this install needs a PO token
+   *
+   * the timestamp is written with the flag rather than beside it, because the
+   * two are one fact: an escalation with no date is one isPotEnabled() cannot
+   * expire, and the whole point of storing it is that it should.
    *
    * a failed write is reported rather than swallowed: a flag that does not
    * reach disk leaves the user blocked again at the next launch, having
@@ -357,7 +389,10 @@ class SettingsStore {
    */
   async setPotEnabled(enabled) {
     try {
-      await this.writeSettings({ pot_enabled: Boolean(enabled) })
+      await this.writeSettings({
+        pot_enabled: Boolean(enabled),
+        pot_enabled_at: enabled ? Date.now() : null
+      })
       return { success: true }
     } catch (error) {
       return { success: false, error: error.message }
@@ -387,4 +422,4 @@ class SettingsStore {
   }
 }
 
-module.exports = { SettingsStore, SETTINGS_FILE }
+module.exports = { SettingsStore, SETTINGS_FILE, POT_ESCALATION_TTL_MS }

--- a/src/main/services/settings-store.js
+++ b/src/main/services/settings-store.js
@@ -327,6 +327,43 @@ class SettingsStore {
     return installId
   }
 
+  /**
+   * whether this install has to send a PO token to be served
+   *
+   * yt-dlp's guidance is to run the default clients, which need no token, and
+   * escalate to `mweb` plus a token provider only once those stop working.
+   * minting a token costs seconds per video, so the escalation is not paid by
+   * every install - only by one that has actually been refused.
+   *
+   * off by default on purpose: the answer for an install nobody has blocked is
+   * "no", and that is also the answer when the settings file cannot be read.
+   *
+   * @returns {Promise<boolean>} true once this install has been refused
+   */
+  async isPotEnabled() {
+    const settings = await this.readAll()
+    return settings.pot_enabled === true
+  }
+
+  /**
+   * remember that this install needs a PO token
+   *
+   * a failed write is reported rather than swallowed: a flag that does not
+   * reach disk leaves the user blocked again at the next launch, having
+   * already paid a failure to discover it.
+   *
+   * @param {boolean} enabled
+   * @returns {Promise<{success: boolean, error?: string}>}
+   */
+  async setPotEnabled(enabled) {
+    try {
+      await this.writeSettings({ pot_enabled: Boolean(enabled) })
+      return { success: true }
+    } catch (error) {
+      return { success: false, error: error.message }
+    }
+  }
+
   /** @returns {Promise<boolean>} analytics is on unless the user turned it off */
   async isAnalyticsEnabled() {
     const settings = await this.readAll()

--- a/src/main/services/ytdlp-engine.js
+++ b/src/main/services/ytdlp-engine.js
@@ -65,6 +65,12 @@ const PROBE_TIMEOUT_MS = 2 * 60 * 1000
 // why the engine lives in a directory now
 const ENGINE_DIR_NAME = "ytdlp"
 
+// the PO token payload sits beside the engine rather than inside it: the
+// updater replaces the engine directory wholesale on every upgrade, and
+// upstream's archives carry no plugins, so anything kept in there is deleted
+// the next time yt-dlp updates itself
+const POT_DIR_NAME = "pot"
+
 // the executable keeps the release asset's own name, and that name differs per
 // platform and per arch - never assume one
 const EXECUTABLE_NAMES = {
@@ -489,7 +495,13 @@ function formatSectionTime(value) {
 }
 
 // common args for every invocation
-function buildCommonArgs({ ffmpegPath, denoPath, cookieFile } = {}) {
+function buildCommonArgs({
+  ffmpegPath,
+  denoPath,
+  cookieFile,
+  potPaths,
+  potEnabled
+} = {}) {
   const args = []
 
   // deno is required for youtube's js challenges since yt-dlp 2025.11.12
@@ -509,6 +521,45 @@ function buildCommonArgs({ ffmpegPath, denoPath, cookieFile } = {}) {
 
   if (cookieFile) {
     args.push("--cookies", cookieFile)
+  }
+
+  /**
+   * the PO token escalation, which is yt-dlp's own and not ours
+   *
+   * their guidance: "By default, yt-dlp will attempt to download videos using
+   * clients that do not currently require a PO Token [...] if you are having
+   * issues with the default clients, it is suggested to use the `mweb` client
+   * with a PO Token." So the default path passes no player_client at all and
+   * gets yt-dlp's own client list, including the fallbacks it adds itself.
+   *
+   * three conditions, each of which alone is a reason to stay quiet:
+   *   - potEnabled: this install has actually been refused. minting costs
+   *     seconds per video and youtube binds a token to the video id, so a new
+   *     one is paid for every new video - not something to charge the ~84% who
+   *     are never blocked
+   *   - potPaths: the payload is installed. missing means degrade to today's
+   *     behaviour, never fail
+   *   - denoPath: the provider runs its generator on the js runtime we ship.
+   *     no runtime, nothing to mint with
+   *
+   * fetch_pot is deliberately not set: it defaults to `auto`, which is yt-dlp
+   * deciding whether the chosen client needs a token for a given context, and
+   * that is the part which tracks youtube's rollout.
+   *
+   * --plugin-dirs is given explicitly rather than relying on a yt-dlp-plugins
+   * folder beside the binary. the engine self-updates by replacing its whole
+   * directory, so anything parked next to it is deleted by the next update -
+   * and the binary itself moves between the bundled copy and the userData one.
+   * naming the directory also means yt-dlp does not scan the user's own plugin
+   * directories, which is code we neither ship nor control.
+   */
+  if (potEnabled && potPaths && denoPath) {
+    args.push("--plugin-dirs", potPaths.pluginDir)
+    args.push("--extractor-args", "youtube:player_client=mweb")
+    args.push(
+      "--extractor-args",
+      `youtubepot-bgutilscript:server_home=${potPaths.serverHome}`
+    )
   }
 
   return args
@@ -1484,6 +1535,12 @@ class YtdlpEngine {
     this.denoPath = options.denoPath || null
     this.cookieFile = options.cookieFile || null
     this.cookieManager = options.cookieManager || null
+    // whether this install has been refused and needs to escalate to a PO
+    // token. it lives on the engine as a plain boolean because run() is
+    // synchronous while the setting it comes from is on disk - whoever reads
+    // settings pushes the answer in here, the same way the engine version is
+    // pushed into analytics
+    this.potEnabled = Boolean(options.potEnabled)
     this.watchdogMs = options.watchdogMs || DEFAULT_WATCHDOG_MS
     this.killGraceMs = options.killGraceMs || KILL_GRACE_MS
     this.spawnFn = options.spawnFn || spawn
@@ -1599,6 +1656,53 @@ class YtdlpEngine {
     return this.denoPath
   }
 
+  /**
+   * where the PO token payload lives, or null when it is not installed
+   *
+   * two halves, both required: `plugin` is the provider yt-dlp loads through
+   * --plugin-dirs, `server` is the generator the provider runs on deno. a jar
+   * with only one of them cannot mint anything, so it is treated as absent
+   * rather than passed on to fail later with a warning nobody reads.
+   *
+   * userData wins over the bundled copy, which is the precedence
+   * getBinaryPath() already uses for the engine: the payload can either ship in
+   * the installer or be downloaded later by the installs that turn out to need
+   * it, and a downloaded copy is the newer of the two.
+   *
+   * @returns {{pluginDir: string, serverHome: string}|null}
+   */
+  /**
+   * remember that this install has to send a PO token from now on
+   *
+   * separate from the constructor because the answer lives in the settings
+   * file, which is read asynchronously long after the engine is built - and
+   * because a refusal can arrive mid-session, at which point every later
+   * operation should escalate without waiting for a restart.
+   *
+   * @param {boolean} enabled
+   */
+  setPotEnabled(enabled) {
+    this.potEnabled = Boolean(enabled)
+  }
+
+  getPotPaths() {
+    const roots = [
+      path.join(this.getUserDataPath(), POT_DIR_NAME),
+      path.join(this.getResourcesPath(), "binaries", POT_DIR_NAME)
+    ]
+
+    for (const root of roots) {
+      const pluginDir = path.join(root, "plugin")
+      const serverHome = path.join(root, "server")
+
+      if (directoryExists(pluginDir) && directoryExists(serverHome)) {
+        return { pluginDir, serverHome }
+      }
+    }
+
+    return null
+  }
+
   // first existing candidate under <resources>/binaries, packaged layout first
   resolveBundled(candidates, allowMissing = false) {
     const base = path.join(this.getResourcesPath(), "binaries")
@@ -1661,7 +1765,10 @@ class YtdlpEngine {
       ffmpegPath: params.ffmpegPath || this.getFfmpegPath(),
       denoPath: params.denoPath || this.getDenoPath(),
       cookieFile:
-        params.cookieFile !== undefined ? params.cookieFile : this.getCookieFile()
+        params.cookieFile !== undefined ? params.cookieFile : this.getCookieFile(),
+      potPaths: params.potPaths !== undefined ? params.potPaths : this.getPotPaths(),
+      potEnabled:
+        params.potEnabled !== undefined ? params.potEnabled : this.potEnabled
     }
 
     const id = options.id || `${operation}_${Date.now()}_${this.operations.size}`

--- a/src/main/services/ytdlp-engine.js
+++ b/src/main/services/ytdlp-engine.js
@@ -524,13 +524,22 @@ function buildCommonArgs({
   }
 
   /**
-   * the PO token escalation, which is yt-dlp's own and not ours
+   * the PO token escalation
    *
-   * their guidance: "By default, yt-dlp will attempt to download videos using
-   * clients that do not currently require a PO Token [...] if you are having
-   * issues with the default clients, it is suggested to use the `mweb` client
-   * with a PO Token." So the default path passes no player_client at all and
-   * gets yt-dlp's own client list, including the fallbacks it adds itself.
+   * all this does is make a token provider reachable. it names no client and
+   * sets no fetch policy, because yt-dlp already owns both: it picks from its
+   * own client list, applies its own fallbacks, and - given a provider - it
+   * notices the client it chose needs a token and fetches one unprompted.
+   * That was verified end to end: no player_client passed, and the log still
+   * read "Generating a gvs PO Token for web client" followed by a download.
+   *
+   * yt-dlp's wiki does suggest `mweb` "if you are having issues with the
+   * default clients", but that advice is written for someone with no provider
+   * at all - the missing token *is* the issue it describes. Pinning a client
+   * here would override the one decision yt-dlp keeps in step with youtube,
+   * and freeze us on whichever client happened to be right today. If telemetry
+   * ever shows the defaults still failing with a provider present, `mweb`
+   * becomes a second escalation step rather than the first.
    *
    * three conditions, each of which alone is a reason to stay quiet:
    *   - potEnabled: this install has actually been refused. minting costs
@@ -555,7 +564,6 @@ function buildCommonArgs({
    */
   if (potEnabled && potPaths && denoPath) {
     args.push("--plugin-dirs", potPaths.pluginDir)
-    args.push("--extractor-args", "youtube:player_client=mweb")
     args.push(
       "--extractor-args",
       `youtubepot-bgutilscript:server_home=${potPaths.serverHome}`

--- a/src/main/services/ytdlp-engine.js
+++ b/src/main/services/ytdlp-engine.js
@@ -129,6 +129,12 @@ const ERROR_METADATA = {
     suggestion: "Check your connection and try again.",
     retryable: true
   },
+  // deliberately not retryable, and deliberately silent about the connection:
+  // the user's network is fine, and retrying is what extends the block
+  [ERROR_CODES.RATE_LIMITED]: {
+    message: "YouTube is temporarily limiting this device.",
+    suggestion: "Wait a few minutes before trying again."
+  },
   [ERROR_CODES.DISK_FULL]: {
     message: "Not enough disk space to save this download.",
     suggestion: "Free up some space and try again."

--- a/src/main/services/ytdlp-updater.js
+++ b/src/main/services/ytdlp-updater.js
@@ -589,47 +589,12 @@ class YtdlpUpdater {
 
   /**
    * put a prepared directory in place of the live one
-   *
-   * both live in userData/engine, so the renames are same-filesystem and
-   * atomic; the old engine is only deleted once the new one is in place, and a
-   * failure halfway puts it straight back
-   *
    * @param {string} preparedDir - directory to move in
    * @param {string} installedDir - directory to replace
    * @returns {Promise<void>}
    */
   async swapIn(preparedDir, installedDir) {
-    const retiredDir = `${installedDir}.retired-${Date.now()}`
-    let retired = false
-
-    try {
-      // whatever is there goes, directory or not - an older build's onefile
-      // could be sitting on this exact path
-      if (await pathExists(installedDir)) {
-        await fsp.rename(installedDir, retiredDir)
-        retired = true
-      }
-
-      await fsp.rename(preparedDir, installedDir)
-    } catch (error) {
-      if (retired) {
-        await removeQuietly(installedDir)
-
-        try {
-          await fsp.rename(retiredDir, installedDir)
-        } catch (restoreError) {
-          // the previous engine is still on disk, just not where the engine
-          // looks for it. losing that fact here is how a user ends up with no
-          // downloader at all, so it travels with the error
-          error.retiredDir = retiredDir
-          error.restoreError = restoreError.message
-        }
-      }
-
-      throw error
-    }
-
-    await removeQuietly(retiredDir)
+    return swapIn(preparedDir, installedDir)
   }
 
   /**
@@ -1011,6 +976,54 @@ function isRedirect(response) {
  * @param {string} destination - directory to create
  * @returns {Promise<void>}
  */
+/**
+ * put a prepared directory in place of the live one
+ *
+ * both directories live under the same userData parent, so the renames are
+ * same-filesystem and atomic; the old copy is only deleted once the new one is
+ * in place, and a failure halfway puts it straight back. nothing ever observes
+ * a half-written directory at the live path, which is the whole point - both
+ * the engine and the PO token payload are found by looking for files inside
+ * one, so a directory that is partly there reads as one that is fully there.
+ *
+ * @param {string} preparedDir - directory to move in
+ * @param {string} installedDir - directory to replace
+ * @returns {Promise<void>}
+ */
+async function swapIn(preparedDir, installedDir) {
+  const retiredDir = `${installedDir}.retired-${Date.now()}`
+  let retired = false
+
+  try {
+    // whatever is there goes, directory or not - an older build's onefile
+    // could be sitting on this exact path
+    if (await pathExists(installedDir)) {
+      await fsp.rename(installedDir, retiredDir)
+      retired = true
+    }
+
+    await fsp.rename(preparedDir, installedDir)
+  } catch (error) {
+    if (retired) {
+      await removeQuietly(installedDir)
+
+      try {
+        await fsp.rename(retiredDir, installedDir)
+      } catch (restoreError) {
+        // the previous engine is still on disk, just not where the engine
+        // looks for it. losing that fact here is how a user ends up with no
+        // downloader at all, so it travels with the error
+        error.retiredDir = retiredDir
+        error.restoreError = restoreError.message
+      }
+    }
+
+    throw error
+  }
+
+  await removeQuietly(retiredDir)
+}
+
 async function copyDirectory(source, destination) {
   await fsp.mkdir(destination, { recursive: true })
 
@@ -1112,6 +1125,10 @@ module.exports = {
   compareVersions,
   releaseAssetFor,
   createHttpClient,
+  // the atomic install, shared with the PO token payload - it lands the same
+  // way, beside the engine, for the same reason
+  swapIn,
+  removeQuietly,
   // exported for tests - the address fallback has no seam through the client
   httpGet,
   resolveAddresses,

--- a/src/main/utils/error-taxonomy.js
+++ b/src/main/utils/error-taxonomy.js
@@ -28,6 +28,10 @@ const ERROR_CATEGORIES = Object.freeze({
   EXTRACTION_FAILED: "EXTRACTION_FAILED",
   INVALID_URL: "INVALID_URL",
   NETWORK_ERROR: "NETWORK_ERROR",
+  // youtube refusing us for asking too often, which is not a network fault and
+  // is made worse by retrying - see the pattern entry for why it must be read
+  // before NETWORK_ERROR
+  RATE_LIMITED: "RATE_LIMITED",
   STALLED: "STALLED",
   DISK_FULL: "DISK_FULL",
   PERMISSION_ERROR: "PERMISSION_ERROR",
@@ -176,6 +180,16 @@ const CATEGORY_PATTERNS = [
       // picked, and an engine update is what fixes it
       /some web client https formats have been skipped/i
     ]
+  },
+  // --- throttling before the generic network entry that used to swallow it ---
+  {
+    // yt-dlp reports a 429 as "unable to download webpage: HTTP Error 429",
+    // which the NETWORK_ERROR entry below matches on its first pattern. that
+    // made a throttled connection look like a broken one, and NETWORK_ERROR is
+    // retryable and says "check your connection" - so we told the user to do
+    // the one thing that deepens a rate limit. this entry has to stay above it.
+    category: ERROR_CATEGORIES.RATE_LIMITED,
+    patterns: [/http error 429/i, /too many requests/i]
   },
   {
     category: ERROR_CATEGORIES.NETWORK_ERROR,

--- a/tests/app-lifecycle.test.js
+++ b/tests/app-lifecycle.test.js
@@ -157,6 +157,7 @@ beforeEach(() => {
     flush: jest.fn().mockResolvedValue(undefined),
     setEnabled: jest.fn().mockResolvedValue({ success: true }),
     setEngineVersion: jest.fn(),
+    setPotEnvironment: jest.fn(),
     isEnabled: jest.fn(() => true)
   }
 
@@ -165,7 +166,8 @@ beforeEach(() => {
     writeSettings: jest.fn().mockResolvedValue(undefined),
     setAnalyticsEnabled: jest.fn().mockResolvedValue({ success: true }),
     isAnalyticsEnabled: jest.fn().mockResolvedValue(true),
-    getInstallId: jest.fn().mockResolvedValue("install-id")
+    getInstallId: jest.fn().mockResolvedValue("install-id"),
+    isPotEnabled: jest.fn().mockResolvedValue(false)
   }
 
   mockIpcHandlers = {
@@ -188,7 +190,10 @@ beforeEach(() => {
     rememberVersion: jest.fn((version) => {
       if (version) knownVersion = version
     }),
-    getKnownVersion: jest.fn(() => knownVersion)
+    getKnownVersion: jest.fn(() => knownVersion),
+    setPotEnabled: jest.fn(),
+    getDenoPath: jest.fn(() => "/tmp/deno"),
+    getPotPaths: jest.fn(() => null)
   }
 
   mockUpdater = {
@@ -250,6 +255,25 @@ describe("initializeServices", () => {
     // id mints racing the same file
     expect(servicesAtIpcConstruction.settingsStore).toBe(mockSettingsStore)
     expect(servicesAtIpcConstruction.analytics).toBe(mockAnalytics)
+  })
+
+  // a refusal is remembered so the user does not have to be refused a second
+  // time to get the benefit of the first. that only works if the stored answer
+  // is put back into the engine before the first operation runs
+  it("arms the engine with a refusal it was told about in an earlier session", async () => {
+    mockSettingsStore.isPotEnabled.mockResolvedValue(true)
+    app.services = {}
+
+    await app.initializeServices()
+
+    expect(mockEngine.setPotEnabled).toHaveBeenCalledWith(true)
+  })
+
+  it("leaves an install nobody has refused paying nothing", async () => {
+    app.services = {}
+    await app.initializeServices()
+
+    expect(mockEngine.setPotEnabled).toHaveBeenCalledWith(false)
   })
 })
 

--- a/tests/error-taxonomy.test.js
+++ b/tests/error-taxonomy.test.js
@@ -314,6 +314,13 @@ describe("parity with the engine's retired pattern table", () => {
     ["unable to download webpage", "NETWORK_ERROR"],
     ["HTTP Error 503: Service Unavailable", "NETWORK_ERROR"],
     ["remote end closed connection without response", "NETWORK_ERROR"],
+    // 429 arrives wrapped in the same "unable to download webpage" wording as a
+    // genuine network fault, so it has to be read before that pattern claims it
+    [
+      "unable to download webpage: HTTP Error 429: Too Many Requests",
+      "RATE_LIMITED"
+    ],
+    ["HTTP Error 429: Too Many Requests", "RATE_LIMITED"],
     ["ffmpeg exited with code 1", "FFMPEG_ERROR"],
     ["ERROR: Postprocessing: something went wrong", "FFMPEG_ERROR"],
     // the engine folded these into one FFMPEG_ERROR; the taxonomy splits them

--- a/tests/pot-escalation.test.js
+++ b/tests/pot-escalation.test.js
@@ -1,0 +1,255 @@
+/**
+ * turning the PO token escalation on, driven through the real ipc handlers.
+ *
+ * yt-dlp's advice is to run the default clients until they stop working and
+ * only then reach for a token provider, so the whole design rests on one
+ * question being answered correctly: what counts as "stopped working". these
+ * tests are about that question and nothing else.
+ */
+
+jest.mock("electron", () => ({
+  ipcMain: { handle: jest.fn(), removeAllListeners: jest.fn() },
+  dialog: { showOpenDialog: jest.fn() },
+  app: { getVersion: jest.fn(() => "1.2.3") },
+  shell: { openExternal: jest.fn(), openPath: jest.fn() }
+}))
+
+const { EventEmitter } = require("events")
+
+const IPCHandlers = require("../src/main/ipc-handlers")
+const { ERROR_CODES } = require("../src/main/services/ytdlp-engine")
+const { PotInstaller } = require("../src/main/services/pot-installer")
+
+const settle = () => new Promise((resolve) => setImmediate(resolve))
+
+class FakeHandle extends EventEmitter {
+  constructor() {
+    super()
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve
+      this.reject = reject
+    })
+    this.promise.catch(() => {})
+  }
+
+  cancel() {
+    return true
+  }
+}
+
+function engineError(code, message) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}
+
+function createHandlers({ infoError, potInstaller } = {}) {
+  const engine = {
+    potEnabled: false,
+    setPotEnabled: jest.fn(function (enabled) {
+      this.potEnabled = Boolean(enabled)
+    }),
+    getPotPaths: jest.fn(() => null),
+    getDenoPath: jest.fn(() => "/deno"),
+    getInfo: jest.fn(() =>
+      infoError ? Promise.reject(infoError) : Promise.resolve({ formats: [] })
+    )
+  }
+
+  const settingsStore = {
+    ensureDownloadPath: jest.fn().mockResolvedValue("/tmp"),
+    setPotEnabled: jest.fn().mockResolvedValue({ success: true })
+  }
+
+  const handlers = new IPCHandlers({
+    cookieManager: { hasValidCookies: jest.fn(() => false) },
+    ytdlpEngine: engine,
+    ytdlpUpdater: null,
+    settingsStore,
+    potInstaller
+  })
+
+  return { handlers, engine, settingsStore }
+}
+
+describe("a refusal turns the escalation on", () => {
+  test("the metadata fetch - where a blocked install fails first", async () => {
+    const { handlers, engine, settingsStore } = createHandlers({
+      infoError: engineError(
+        ERROR_CODES.BOT_DETECTION,
+        "Sign in to confirm you're not a bot"
+      )
+    })
+
+    await handlers.handleGetVideoInfo(null, {
+      url: "https://youtube.com/watch?v=x",
+      platform: "youtube"
+    })
+    await settle()
+
+    // the live engine, so the very next paste escalates without a restart...
+    expect(engine.setPotEnabled).toHaveBeenCalledWith(true)
+    // ...and the settings file, so a restart does not have to relearn it
+    expect(settingsStore.setPotEnabled).toHaveBeenCalledWith(true)
+  })
+
+  test("a download that is refused after the fetch got through", async () => {
+    const { handlers, engine, settingsStore } = createHandlers()
+    const handle = new FakeHandle()
+
+    handlers.runner.reserve("download_1", { type: "combined", platform: "youtube" })
+    handlers.startDownload({
+      downloadId: "download_1",
+      type: "combined",
+      platform: "youtube",
+      formatId: "1080p",
+      createHandle: () => handle
+    })
+
+    await settle()
+    handle.reject(
+      engineError(ERROR_CODES.BOT_DETECTION, "Sign in to confirm you're not a bot")
+    )
+    await settle()
+    await settle()
+
+    expect(engine.setPotEnabled).toHaveBeenCalledWith(true)
+    expect(settingsStore.setPotEnabled).toHaveBeenCalledWith(true)
+  })
+})
+
+describe("everything else leaves it alone", () => {
+  /**
+   * the one that matters most, because it is the trigger this design was
+   * talked out of. throttling reads as a refusal and is not one: the audit
+   * found it landing mostly on installs youtube had never blocked, which makes
+   * it a reading of the user's network. escalating on it would charge a token
+   * mint per video to people whose only problem was a bad minute of wifi.
+   */
+  test("rate limiting is not a refusal", async () => {
+    const { handlers, engine, settingsStore } = createHandlers({
+      infoError: engineError(
+        ERROR_CODES.RATE_LIMITED,
+        "Unable to download webpage: HTTP Error 429"
+      )
+    })
+
+    await handlers.handleGetVideoInfo(null, {
+      url: "https://youtube.com/watch?v=x",
+      platform: "youtube"
+    })
+    await settle()
+
+    expect(engine.setPotEnabled).not.toHaveBeenCalled()
+    expect(settingsStore.setPotEnabled).not.toHaveBeenCalled()
+  })
+
+  test("a video that simply is not there is not a refusal", async () => {
+    const { handlers, engine } = createHandlers({
+      infoError: engineError(
+        ERROR_CODES.VIDEO_UNAVAILABLE,
+        "Video unavailable"
+      )
+    })
+
+    await handlers.handleGetVideoInfo(null, {
+      url: "https://youtube.com/watch?v=x",
+      platform: "youtube"
+    })
+    await settle()
+
+    expect(engine.setPotEnabled).not.toHaveBeenCalled()
+  })
+
+  test("a cancelled download is not a refusal", async () => {
+    const { handlers, engine } = createHandlers()
+    const handle = new FakeHandle()
+
+    handlers.runner.reserve("download_1", { type: "combined", platform: "youtube" })
+    handlers.startDownload({
+      downloadId: "download_1",
+      type: "combined",
+      platform: "youtube",
+      formatId: "1080p",
+      createHandle: () => handle
+    })
+
+    await settle()
+    handlers.runner.cancel("download_1")
+    await settle()
+    await settle()
+
+    expect(engine.setPotEnabled).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * the sentence appended to the error is a promise, and it is only ours to make
+ * when a payload can really arrive. no artifact is published yet, so the
+ * shipping answer to "is a fix on its way" is no - and a user told to try again
+ * in a minute would retry into the same wall for the life of the install.
+ */
+describe("what the user is told", () => {
+  const refused = () =>
+    engineError(ERROR_CODES.BOT_DETECTION, "Sign in to confirm you're not a bot")
+
+  test("no payload to fetch means no fix is promised", async () => {
+    const { handlers } = createHandlers({
+      infoError: refused(),
+      // the real one, with the real empty checksum table
+      potInstaller: new PotInstaller({ engine: { getUserDataPath: () => "/tmp" } })
+    })
+
+    const response = await handlers.handleGetVideoInfo(null, {
+      url: "https://youtube.com/watch?v=x",
+      platform: "youtube"
+    })
+    await settle()
+
+    expect(response.error.message).toBe("Sign in to confirm you're not a bot")
+    // the escalation itself still happens - it costs nothing and outlives this
+    expect(handlers.engine.setPotEnabled).toHaveBeenCalledWith(true)
+  })
+
+  test("a fetch that really starts says so, once", async () => {
+    const { handlers } = createHandlers({
+      infoError: refused(),
+      potInstaller: {
+        canInstall: () => true,
+        ensureInstalled: jest.fn().mockResolvedValue({ installed: true })
+      }
+    })
+
+    const response = await handlers.handleGetVideoInfo(null, {
+      url: "https://youtube.com/watch?v=x",
+      platform: "youtube"
+    })
+    await settle()
+
+    expect(response.error.message).toContain("Setting up a fix in the background")
+  })
+})
+
+// the write is fired rather than awaited, so the user is answered at the speed
+// of the failure rather than the speed of the disk. that is only safe if a
+// rejected write cannot escape as an unhandled rejection
+test("a settings write that fails does not break the operation reporting it", async () => {
+  const { handlers, engine, settingsStore } = createHandlers({
+    infoError: engineError(
+      ERROR_CODES.BOT_DETECTION,
+      "Sign in to confirm you're not a bot"
+    )
+  })
+
+  settingsStore.setPotEnabled.mockRejectedValue(new Error("disk is full"))
+
+  const response = await handlers.handleGetVideoInfo(null, {
+    url: "https://youtube.com/watch?v=x",
+    platform: "youtube"
+  })
+  await settle()
+
+  expect(response.success).toBe(false)
+  // the session still escalates: only the memory of it was lost
+  expect(engine.setPotEnabled).toHaveBeenCalledWith(true)
+})

--- a/tests/pot-installer.test.js
+++ b/tests/pot-installer.test.js
@@ -1,0 +1,266 @@
+/**
+ * fetching the PO token payload into userData/pot.
+ *
+ * the whole point of this service is that it can fail without anyone noticing,
+ * so these are about the three ways that promise could quietly break: bytes we
+ * did not vouch for getting installed, a half-written payload becoming visible
+ * at the live path, and a failure escaping into the operation that triggered it.
+ */
+
+const crypto = require("crypto")
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+
+const { makeZip } = require("./helpers/zip-fixture")
+const { PotInstaller, VERSION_MARKER } = require("../src/main/services/pot-installer")
+
+let root
+let potDir
+
+// a payload with both of the halves getPotPaths() insists on
+const PAYLOAD_ENTRIES = [
+  { name: "plugin/bgutil-plugin.zip", data: Buffer.from("not really a zip") },
+  { name: "server/src/generate_once.ts", data: Buffer.from("console.log(1)") },
+  { name: "server/package.json", data: Buffer.from('{"version":"1.3.2"}') }
+]
+
+const sha256 = (buffer) => crypto.createHash("sha256").update(buffer).digest("hex")
+
+// every file under a directory, ignoring the version marker the installer adds
+function countFiles(dir) {
+  if (!fs.existsSync(dir)) return 0
+
+  let total = 0
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true, recursive: true })) {
+    if (entry.isFile() && entry.name !== VERSION_MARKER) total++
+  }
+
+  return total
+}
+
+/**
+ * an installer whose engine reports the payload the way the real one does -
+ * by looking on disk for both halves - so the presence checks under test are
+ * answered by the filesystem rather than by a flag the test sets
+ */
+function createInstaller({ archive, download } = {}) {
+  const engine = {
+    getUserDataPath: () => root,
+    getPotPaths: () => {
+      const pluginDir = path.join(potDir, "plugin")
+      const serverHome = path.join(potDir, "server")
+
+      return fs.existsSync(pluginDir) && fs.existsSync(serverHome)
+        ? { pluginDir, serverHome }
+        : null
+    }
+  }
+
+  const http = {
+    download:
+      download ||
+      jest.fn(async (_url, destPath) => {
+        fs.writeFileSync(destPath, archive)
+        return sha256(archive)
+      })
+  }
+
+  return { installer: new PotInstaller({ engine, http }), http, engine }
+}
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "cliply-pot-"))
+  potDir = path.join(root, "pot")
+  process.env.CLIPLY_POT_SHA256 = sha256(makeZip(PAYLOAD_ENTRIES))
+})
+
+afterEach(() => {
+  delete process.env.CLIPLY_POT_SHA256
+  delete process.env.CLIPLY_POT_BASE_URL
+  fs.rmSync(root, { recursive: true, force: true })
+})
+
+test("installs a payload whose bytes match what we vouched for", async () => {
+  const { installer } = createInstaller({ archive: makeZip(PAYLOAD_ENTRIES) })
+
+  const result = await installer.ensureInstalled()
+
+  expect(result.installed).toBe(true)
+  expect(fs.existsSync(path.join(potDir, "plugin"))).toBe(true)
+  expect(fs.existsSync(path.join(potDir, "server"))).toBe(true)
+})
+
+// not in scope to refresh it, but the version has to be readable by whatever
+// eventually does - the plugin and the generator are version-locked, so
+// replacing them means first knowing what is there
+test("records what it installed", async () => {
+  const { installer } = createInstaller({ archive: makeZip(PAYLOAD_ENTRIES) })
+
+  await installer.ensureInstalled()
+
+  const marker = JSON.parse(
+    fs.readFileSync(path.join(potDir, VERSION_MARKER), "utf8")
+  )
+  expect(marker.version).toBe("1.3.2")
+})
+
+describe("nothing unverified is ever installed", () => {
+  test("a payload that does not match its checksum is refused", async () => {
+    const { installer } = createInstaller({ archive: makeZip(PAYLOAD_ENTRIES) })
+    process.env.CLIPLY_POT_SHA256 = "0".repeat(64)
+
+    const result = await installer.ensureInstalled()
+
+    expect(result.installed).toBe(false)
+    expect(result.reason).toBe("checksum-mismatch")
+    expect(fs.existsSync(potDir)).toBe(false)
+  })
+
+  // the state this ships in: no artifact is published yet, so there is no
+  // digest to pin and the installer must decline rather than fetch whatever
+  // answers the url
+  test("an asset nobody has vouched for is never fetched at all", async () => {
+    const { installer, http } = createInstaller({ archive: makeZip(PAYLOAD_ENTRIES) })
+    delete process.env.CLIPLY_POT_SHA256
+
+    const result = await installer.ensureInstalled()
+
+    expect(result.installed).toBe(false)
+    expect(result.reason).toBe("no-payload-published")
+    expect(http.download).not.toHaveBeenCalled()
+  })
+
+  test("an archive missing half the payload is refused", async () => {
+    // the engine treats plugin-without-server as absent, so installing this
+    // would leave a directory that is never used and never replaced
+    const halfPayload = makeZip([PAYLOAD_ENTRIES[0]])
+    const { installer } = createInstaller({ archive: halfPayload })
+    process.env.CLIPLY_POT_SHA256 = sha256(halfPayload)
+
+    const result = await installer.ensureInstalled()
+
+    expect(result.installed).toBe(false)
+    expect(result.reason).toBe("payload-layout-unexpected")
+    expect(fs.existsSync(potDir)).toBe(false)
+  })
+})
+
+describe("the app carries on regardless", () => {
+  test("a download that throws is reported, not raised", async () => {
+    const { installer } = createInstaller({
+      download: jest.fn().mockRejectedValue(new Error("network is down"))
+    })
+
+    const result = await installer.ensureInstalled()
+
+    expect(result.installed).toBe(false)
+    expect(result.reason).toBe("install-failed")
+    // and the engine still finds no payload, which is exactly today's behaviour
+    expect(fs.existsSync(potDir)).toBe(false)
+  })
+
+  test("a failed attempt leaves nothing behind for the next one to trip on", async () => {
+    const { installer } = createInstaller({
+      download: jest.fn().mockRejectedValue(new Error("network is down"))
+    })
+
+    await installer.ensureInstalled()
+
+    expect(fs.readdirSync(root)).toEqual([])
+  })
+})
+
+describe("one install at a time", () => {
+  test("a user retrying three times starts one download", async () => {
+    let release
+    const gate = new Promise((resolve) => {
+      release = resolve
+    })
+    const archive = makeZip(PAYLOAD_ENTRIES)
+
+    const download = jest.fn(async (_url, destPath) => {
+      await gate
+      fs.writeFileSync(destPath, archive)
+      return sha256(archive)
+    })
+
+    const { installer } = createInstaller({ download })
+
+    const all = Promise.all([
+      installer.ensureInstalled(),
+      installer.ensureInstalled(),
+      installer.ensureInstalled()
+    ])
+
+    release()
+    const results = await all
+
+    expect(download).toHaveBeenCalledTimes(1)
+    expect(results.every((result) => result.installed)).toBe(true)
+  })
+
+  test("a payload that is already there costs no network at all", async () => {
+    const { installer, http } = createInstaller({ archive: makeZip(PAYLOAD_ENTRIES) })
+
+    await installer.ensureInstalled()
+    http.download.mockClear()
+
+    const again = await installer.ensureInstalled()
+
+    expect(again.reason).toBe("already-installed")
+    expect(http.download).not.toHaveBeenCalled()
+  })
+})
+
+/**
+ * the reason the install is a rename rather than an unpack in place.
+ *
+ * getPotPaths() accepts any directory holding a `plugin` and a `server`, so a
+ * pot/ that is midway through being written satisfies it - and the engine
+ * would then hand yt-dlp a --plugin-dirs pointing at a tree still being
+ * filled in. unpacking into a staging directory means the live path only ever
+ * appears complete.
+ */
+test("the live path never exists in a half-written state", async () => {
+  // enough entries that unpacking spans many ticks of the event loop - the
+  // window this is about is the one *inside* extractZip, which awaits per
+  // entry, and a three-file payload closes it too fast to observe
+  const wide = [
+    { name: "plugin/bgutil-plugin.zip", data: Buffer.from("not really a zip") },
+    ...Array.from({ length: 400 }, (_, index) => ({
+      name: `server/node_modules/pkg-${index}/index.js`,
+      data: Buffer.from(`module.exports = ${index}`)
+    }))
+  ]
+  const archive = makeZip(wide)
+
+  const { installer, engine } = createInstaller({ archive })
+  process.env.CLIPLY_POT_SHA256 = sha256(archive)
+
+  // what the engine would see, sampled throughout: is there a payload, and if
+  // so is all of it there
+  const seen = []
+  const watch = setInterval(() => {
+    seen.push({
+      visible: Boolean(engine.getPotPaths()),
+      files: countFiles(potDir)
+    })
+  }, 0)
+
+  await installer.ensureInstalled()
+  clearInterval(watch)
+
+  // the sampler has to have actually run, or this proves nothing
+  expect(seen.length).toBeGreaterThan(0)
+
+  // the property under test: the moment the payload becomes visible to the
+  // engine, all of it is there. a visible-but-short observation is the engine
+  // pointing yt-dlp at a tree still being filled in
+  const partial = seen.filter((sample) => sample.visible && sample.files < wide.length)
+  expect(partial).toEqual([])
+
+  expect(engine.getPotPaths()).not.toBeNull()
+  expect(countFiles(potDir)).toBe(wide.length)
+})

--- a/tests/settings-store.test.js
+++ b/tests/settings-store.test.js
@@ -4,7 +4,10 @@ const fs = require("fs")
 const os = require("os")
 const path = require("path")
 
-const { SettingsStore } = require("../src/main/services/settings-store")
+const {
+  SettingsStore,
+  POT_ESCALATION_TTL_MS
+} = require("../src/main/services/settings-store")
 
 let root
 let store
@@ -185,6 +188,47 @@ describe("po token escalation", () => {
 
     expect(result.success).toBe(false)
     expect(typeof result.error).toBe("string")
+  })
+
+  // backdate the stored escalation without waiting a week for one
+  const refusedAgo = (ms) =>
+    fs.writeFileSync(
+      store.settingsFile,
+      JSON.stringify({ pot_enabled: true, pot_enabled_at: Date.now() - ms })
+    )
+
+  // a quarter of the blocked installs went on to succeed with no change from
+  // us, so the escalation has to be able to switch itself back off - otherwise
+  // those users pay a token mint per video forever for a block that has lifted
+  describe("expiry", () => {
+    test("holds right up to the last moment of the window", async () => {
+      refusedAgo(POT_ESCALATION_TTL_MS - 60_000)
+
+      expect(await store.isPotEnabled()).toBe(true)
+    })
+
+    test("lapses once the window has passed", async () => {
+      refusedAgo(POT_ESCALATION_TTL_MS + 60_000)
+
+      expect(await store.isPotEnabled()).toBe(false)
+    })
+
+    test("re-arms on the next refusal, dated from that one", async () => {
+      refusedAgo(POT_ESCALATION_TTL_MS + 60_000)
+      expect(await store.isPotEnabled()).toBe(false)
+
+      await store.setPotEnabled(true)
+
+      // the fresh refusal has to restart the clock rather than land inside the
+      // window that just closed, or a long-blocked install expires permanently
+      expect(await store.isPotEnabled()).toBe(true)
+    })
+
+    test("treats an escalation with no date as lapsed", async () => {
+      fs.writeFileSync(store.settingsFile, JSON.stringify({ pot_enabled: true }))
+
+      expect(await store.isPotEnabled()).toBe(false)
+    })
   })
 })
 

--- a/tests/settings-store.test.js
+++ b/tests/settings-store.test.js
@@ -157,6 +157,37 @@ function tempFilesIn(dir) {
   return fs.readdirSync(dir).filter((name) => name.endsWith(".tmp"))
 }
 
+// yt-dlp's own advice is to use the default clients until they stop working,
+// and only then escalate to a client that needs a PO token. an install that
+// has been refused once stays refused - the block follows the connection, not
+// the request - so the escalation is remembered rather than rediscovered.
+describe("po token escalation", () => {
+  test("starts off, so an install that was never refused pays nothing", async () => {
+    expect(await store.isPotEnabled()).toBe(false)
+  })
+
+  test("stays on once an install has been refused", async () => {
+    await store.setPotEnabled(true)
+
+    expect(await store.isPotEnabled()).toBe(true)
+    // and it survives the process that set it - a flag only held in memory
+    // would re-block the user on every launch
+    const relaunched = new SettingsStore({ settingsFile: store.settingsFile })
+    expect(await relaunched.isPotEnabled()).toBe(true)
+  })
+
+  test("reports a write it could not persist", async () => {
+    const unwritable = new SettingsStore({
+      settingsFile: path.join(root, "no-such-dir", "\0bad", "settings.json")
+    })
+
+    const result = await unwritable.setPotEnabled(true)
+
+    expect(result.success).toBe(false)
+    expect(typeof result.error).toBe("string")
+  })
+})
+
 describe("analytics preferences", () => {
   test("generates an install id once and reuses it", async () => {
     const first = await store.getInstallId()

--- a/tests/ytdlp-engine.test.js
+++ b/tests/ytdlp-engine.test.js
@@ -81,6 +81,71 @@ describe("common args", () => {
   })
 })
 
+// yt-dlp's default clients need no PO token, so the escalation is only for an
+// install that has already been refused. see the PO Token Guide: the prescribed
+// setup is the `mweb` client plus a provider plugin.
+describe("po token escalation", () => {
+  const POT = {
+    ...PATHS,
+    potPaths: { pluginDir: "/res/binaries/pot/plugin", serverHome: "/res/binaries/pot/server" }
+  }
+
+  test("asks for nothing extra until the install has been refused", () => {
+    const args = buildCommonArgs(POT)
+
+    expect(args).not.toContain("--plugin-dirs")
+    expect(args.join(" ")).not.toContain("player_client")
+  })
+
+  test("escalates to the mweb client and the provider once enabled", () => {
+    const args = buildCommonArgs({ ...POT, potEnabled: true })
+
+    expect(valueAfter(args, "--plugin-dirs")).toBe("/res/binaries/pot/plugin")
+    expect(args).toContain("youtube:player_client=mweb")
+    expect(args).toContain(
+      "youtubepot-bgutilscript:server_home=/res/binaries/pot/server"
+    )
+  })
+
+  // fetch_pot defaults to `auto`, which is yt-dlp deciding whether the chosen
+  // client actually needs a token. overriding it would be us second-guessing
+  // the one component that tracks youtube's rollout
+  test("leaves the fetch policy at yt-dlp's own default", () => {
+    expect(buildCommonArgs({ ...POT, potEnabled: true }).join(" ")).not.toContain(
+      "fetch_pot"
+    )
+  })
+
+  // the provider runs its generator on the js runtime we ship. without deno
+  // there is nothing to run it, so asking for a token would only buy a warning
+  test("stays quiet when there is no js runtime to mint with", () => {
+    const args = buildCommonArgs({ ...POT, denoPath: null, potEnabled: true })
+
+    expect(args).not.toContain("--plugin-dirs")
+  })
+
+  test("stays quiet when the payload has not been installed", () => {
+    const args = buildCommonArgs({ ...PATHS, potEnabled: true })
+
+    expect(args).not.toContain("--plugin-dirs")
+  })
+
+  // --no-js-runtimes must keep leading --js-runtimes. reversed, the runtime is
+  // disabled after being named: the provider goes unavailable and yt-dlp's own
+  // challenge solver dies with it. verified against 2026.08.19
+  test("keeps the js runtime flags in the only order that works", () => {
+    const args = buildCommonArgs({ ...POT, potEnabled: true })
+
+    expect(
+      containsSequence(args, [
+        "--no-js-runtimes",
+        "--js-runtimes",
+        "deno:/res/binaries/deno/deno"
+      ])
+    ).toBe(true)
+  })
+})
+
 describe("info args", () => {
   test("dumps json without downloading", () => {
     const args = buildArgs("info", { ...PATHS, url: "https://youtu.be/abc" })
@@ -1171,5 +1236,81 @@ describe("cookie file detection", () => {
     expect(buildCommonArgs({ cookieFile: engine.getCookieFile() })).toContain(
       "--cookies"
     )
+  })
+})
+
+describe("locating the po token payload", () => {
+  const { YtdlpEngine } = require("../src/main/services/ytdlp-engine")
+  let tempDir
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cliply-pot-"))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  // both halves are needed to mint anything: the plugin is what yt-dlp loads,
+  // the server is what the plugin runs. half an install is not an install
+  function seed(base, parts = ["plugin", "server"]) {
+    for (const part of parts) {
+      fs.mkdirSync(path.join(base, "pot", part), { recursive: true })
+    }
+  }
+
+  test("finds nothing when the payload was never installed", () => {
+    const engine = new YtdlpEngine({
+      userDataPath: tempDir,
+      resourcesPath: tempDir
+    })
+
+    expect(engine.getPotPaths()).toBeNull()
+  })
+
+  test("uses the copy that ships with the app", () => {
+    const resources = path.join(tempDir, "resources")
+    seed(path.join(resources, "binaries"))
+
+    const engine = new YtdlpEngine({
+      userDataPath: path.join(tempDir, "userdata"),
+      resourcesPath: resources
+    })
+
+    expect(engine.getPotPaths()).toEqual({
+      pluginDir: path.join(resources, "binaries", "pot", "plugin"),
+      serverHome: path.join(resources, "binaries", "pot", "server")
+    })
+  })
+
+  // the payload can also arrive after install, downloaded only by the users who
+  // turn out to need it. a downloaded copy is the newer one, so it wins - the
+  // same precedence getBinaryPath() already uses for the engine itself
+  test("prefers a downloaded copy over the bundled one", () => {
+    const resources = path.join(tempDir, "resources")
+    const userData = path.join(tempDir, "userdata")
+    seed(path.join(resources, "binaries"))
+    seed(userData)
+
+    const engine = new YtdlpEngine({
+      userDataPath: userData,
+      resourcesPath: resources
+    })
+
+    expect(engine.getPotPaths().pluginDir).toBe(
+      path.join(userData, "pot", "plugin")
+    )
+  })
+
+  test("refuses a half-installed payload rather than minting with part of it", () => {
+    const userData = path.join(tempDir, "userdata")
+    seed(userData, ["plugin"])
+
+    const engine = new YtdlpEngine({
+      userDataPath: userData,
+      resourcesPath: path.join(tempDir, "resources")
+    })
+
+    expect(engine.getPotPaths()).toBeNull()
   })
 })

--- a/tests/ytdlp-engine.test.js
+++ b/tests/ytdlp-engine.test.js
@@ -97,14 +97,19 @@ describe("po token escalation", () => {
     expect(args.join(" ")).not.toContain("player_client")
   })
 
-  test("escalates to the mweb client and the provider once enabled", () => {
+  test("offers the provider without dictating a client", () => {
     const args = buildCommonArgs({ ...POT, potEnabled: true })
 
     expect(valueAfter(args, "--plugin-dirs")).toBe("/res/binaries/pot/plugin")
-    expect(args).toContain("youtube:player_client=mweb")
     expect(args).toContain(
       "youtubepot-bgutilscript:server_home=/res/binaries/pot/server"
     )
+    // making the provider reachable is the whole escalation. given one,
+    // yt-dlp picks a client, notices that client needs a token and fetches it
+    // with no instruction from us - verified end to end. naming a client here
+    // would override the one choice yt-dlp keeps in step with youtube, and
+    // pin us to whichever client was right on the day this was written
+    expect(args.join(" ")).not.toContain("player_client")
   })
 
   // fetch_pot defaults to `auto`, which is yt-dlp deciding whether the chosen

--- a/tests/ytdlp-engine.test.js
+++ b/tests/ytdlp-engine.test.js
@@ -952,6 +952,20 @@ describe("error mapping", () => {
     expect(result.retryable).toBe(true)
   })
 
+  // a throttled connection is the one failure where our own advice made the
+  // problem worse: NETWORK_ERROR told the user to retry, and retrying is what
+  // deepens a rate limit. it must not be retryable, and it must not blame the
+  // user's connection - theirs is fine, it is youtube refusing us
+  test("rate limiting is not retryable and does not blame the connection", () => {
+    const result = map(
+      "ERROR: unable to download webpage: HTTP Error 429: Too Many Requests"
+    )
+
+    expect(result.code).toBe(ERROR_CODES.RATE_LIMITED)
+    expect(result.retryable).toBe(false)
+    expect(`${result.message} ${result.suggestion}`).not.toMatch(/connection/i)
+  })
+
   test("extraction failures are the ones an update can fix", () => {
     const result = map("ERROR: [youtube] abc: nsig extraction failed: Some players may fail")
 

--- a/tests/ytdlp-lifecycle.test.js
+++ b/tests/ytdlp-lifecycle.test.js
@@ -1046,7 +1046,9 @@ describe("po token escalation reaches the spawned process", () => {
     const args = await argsFor({ potEnabled: true })
 
     expect(args).toContain("--plugin-dirs")
-    expect(args).toContain("youtube:player_client=mweb")
+    expect(args.join(" ")).toContain("youtubepot-bgutilscript:server_home=")
+    // the client stays yt-dlp's call, here as everywhere else
+    expect(args.join(" ")).not.toContain("player_client")
   })
 
   test("sends nothing extra for an install that was never refused", async () => {

--- a/tests/ytdlp-lifecycle.test.js
+++ b/tests/ytdlp-lifecycle.test.js
@@ -1007,3 +1007,49 @@ describe("the version the engine knows", () => {
     expect(await version).toBe("2026.09.01")
   })
 })
+
+// the escalation has to survive the trip through run(): buildCommonArgs is
+// unit-tested on its own inputs, which proves nothing about whether the engine
+// actually hands it the flag and the payload it resolved
+describe("po token escalation reaches the spawned process", () => {
+  const fs = require("fs")
+  let payloadRoot
+
+  beforeEach(() => {
+    payloadRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cliply-pot-run-"))
+    for (const part of ["plugin", "server"]) {
+      fs.mkdirSync(path.join(payloadRoot, "pot", part), { recursive: true })
+    }
+  })
+
+  afterEach(() => {
+    fs.rmSync(payloadRoot, { recursive: true, force: true })
+  })
+
+  // run one download to completion and hand back what was spawned
+  async function argsFor(options) {
+    const spawnFn = createSpawner()
+    const engine = createEngine(spawnFn, { userDataPath: payloadRoot, ...options })
+
+    const handle = engine.downloadCombined(DOWNLOAD)
+    await settle()
+
+    spawnFn.children[0].say("CLIPLY_FILE|/tmp/downloads/out.mp4\n")
+    await settle()
+    spawnFn.children[0].exit(0)
+    await handle.promise
+
+    return spawnFn.calls[0].args
+  }
+
+  test("sends the provider once the install has been refused", async () => {
+    const args = await argsFor({ potEnabled: true })
+
+    expect(args).toContain("--plugin-dirs")
+    expect(args).toContain("youtube:player_client=mweb")
+  })
+
+  test("sends nothing extra for an install that was never refused", async () => {
+    expect(await argsFor({})).not.toContain("--plugin-dirs")
+  })
+})


### PR DESCRIPTION
## The problem

YouTube refuses **43 users — 14.1% of everyone who pastes a link**. Those installs fail 190 times against 24 successes, and only 9 of the 43 ever complete a download. **41 of the 43 are on Windows.**

The cause is settled, reproduced twice independently: Cliply solves YouTube's JS challenges correctly — Deno is bundled and working — but sends no proof-of-origin token, so yt-dlp reports `PO Token Providers: none` and YouTube turns us away.

## The approach: delegate to yt-dlp

yt-dlp's own guidance is a two-tier escalation, not a switch — run the default clients until they stop working, and only then reach for a token provider. That is what this implements, and the deference is deliberate throughout:

- **No `player_client`.** yt-dlp picks its own clients and applies its own fallbacks. An earlier version named `mweb` and was removed — that advice answers a different question, one asked by someone with no provider at all.
- **`fetch_pot` stays at `auto`.** That is yt-dlp deciding whether the chosen client needs a token, and it is the part that tracks YouTube's rollout.
- **The provider is `bgutil-ytdlp-pot-provider`**, the one yt-dlp features in its own documentation, run in the script mode it recommends, on the Deno we already ship.

## What lands

| Commit | |
|---|---|
| `fix: declare the license the repo actually ships` | LICENSE has been GPLv3 since Aug 2025; package.json still carried the scaffolding default |
| `fix: stop reading a throttled connection as a broken one` | A 429 matched `NETWORK_ERROR`, so we told throttled users to check their connection and retry — the one thing that deepens a rate limit |
| `feat: teach the engine yt-dlp's own po token escalation` | The engine half: how to ask, and when to stay quiet |
| `fix: leave the player client to yt-dlp, provider and all` | Drops `mweb` |
| `refactor: make the atomic install shareable` | `swapIn()` moves to module scope. No behaviour change |
| `feat: let analytics say what an install could mint a po token with` | `deno_present` and `pot_provider` on every event |
| `feat: fetch a po token payload when youtube refuses an install` | The trigger, the expiry, and the on-demand installer |

## Design decisions worth reviewing

**`BOT_DETECTION` is the only trigger.** Not `RATE_LIMITED` — the audit found throttling landing mostly on installs YouTube had never blocked (69 events across 25 never-blocked users, against 23 across 5 blocked ones), which makes it a reading of the user's network. Not a cancelled download either, which settles wearing the same `success: false`.

**The escalation expires after 7 days.** 11 of the 43 blocked installs later succeeded with no change from us, so blocks lift on their own. Every refusal re-stamps the window.

**The payload is fetched on demand, not bundled.** ~86% of installs are never refused and download nothing. Verified against a pinned digest, unpacked to staging, swapped in atomically — `getPotPaths()` accepts a `plugin/`+`server/` pair the instant both exist and would hand yt-dlp a half-written one.

**Nothing here can fail a download.** An absent payload is a state the engine already handles: the flags are omitted and behaviour is byte-identical to today. Every failure resolves to a reason rather than throwing, and neither the settings write nor the download is awaited by the request that triggered it.

## Verified

End to end on **macOS arm64** and **Windows x64** (CI) — payload built, installed, and a real token minted through the real yt-dlp on both:

```
[youtube] [pot:bgutil:script-deno] Generating a gvs PO Token for web client via bgutil script
[debug] [youtube] dQw4w9WgXcQ: Retrieved a gvs PO Token for web client
```

Windows specifics: `canvas` installs prebuilt, zero symlinks in the tree, 51.5 MB payload, atomic swap works on backslash paths. 748 tests pass.

## Known limits — read before merging

- **`POT_CHECKSUMS` is empty, so this is inert in production.** It declines rather than trusting whatever answers the URL. Publishing per-platform artifacts to the `binaries` release tag and pinning their digests is follow-up work, and nothing ships to users until it happens.
- **No refresh path yet.** `yt-dlp -U` updates the binary only; yt-dlp has no plugin update facility, so drift against a self-updating engine is ours to handle. The installed version is recorded and `ensureInstalled()` is idempotent so this can hang off the existing periodic update pass.
- **macOS + `canvas` under hardened runtime is unverified** — whether downloaded unsigned native code loads in the signed app. Affects 3 of 43 blocked users; macOS can fall back to a canvas-free payload.

## Found along the way, not fixed here

- The Jest suite has never run on Windows and 13 tests fail there — POSIX signals, permission bits, ad-hoc signing. All PO token suites pass. Unclear whether the code is POSIX-only or only the tests.
- `package.json` points `entitlements` at `build/entitlements.mac.plist`, and there is no `build/` directory in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)