### PR TITLE
Pin the published PO token payloads, and go live

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cliply-desktop",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Desktop YouTube downloader with segment support",
   "main": "src/main/index.js",
   "homepage": "./",

--- a/src/main/services/pot-installer.js
+++ b/src/main/services/pot-installer.js
@@ -47,7 +47,12 @@ const DEFAULT_BASE_URL =
  * being empty is the correct state today: it makes the installer inert until
  * the artifacts exist, instead of trusting whatever answers the url.
  */
-const POT_CHECKSUMS = {}
+const POT_CHECKSUMS = {
+  "pot-1.3.2-darwin-arm64.zip":
+    "7357586086aaf6b116af1acbc3051723c8e98104777764efe9a54dd2e233a240",
+  "pot-1.3.2-win32-x64.zip":
+    "57d9db2a1494becf7e434292cbec30fa05577661da31f2ed013bbc92bca932de"
+}
 
 // the payload is a node_modules tree; a slow connection needs room for ~70 mb
 const INSTALL_TIMEOUT_MS = 10 * 60 * 1000
@@ -269,5 +274,9 @@ module.exports = {
   PotInstaller,
   payloadAssetFor,
   POT_VERSION,
-  VERSION_MARKER
+  VERSION_MARKER,
+  // exported for tests - "an asset nobody vouched for is refused" has no seam
+  // once every shipping platform has a digest, and it is the guard that keeps
+  // an unpublished platform from fetching whatever answers the url
+  POT_CHECKSUMS
 }

--- a/src/main/services/ytdlp-engine.js
+++ b/src/main/services/ytdlp-engine.js
@@ -1774,10 +1774,19 @@ class YtdlpEngine {
       denoPath: params.denoPath || this.getDenoPath(),
       cookieFile:
         params.cookieFile !== undefined ? params.cookieFile : this.getCookieFile(),
-      potPaths: params.potPaths !== undefined ? params.potPaths : this.getPotPaths(),
+      // buildCommonArgs needs both, and needs potEnabled first - so an install
+      // that was never refused, which is most of them, does not pay two stat
+      // calls per operation to look for a payload it would not use anyway
       potEnabled:
         params.potEnabled !== undefined ? params.potEnabled : this.potEnabled
     }
+
+    resolved.potPaths =
+      params.potPaths !== undefined
+        ? params.potPaths
+        : resolved.potEnabled
+          ? this.getPotPaths()
+          : null
 
     const id = options.id || `${operation}_${Date.now()}_${this.operations.size}`
     const isInfo = operation === "info" || operation === "playlist-info"

--- a/src/main/services/ytdlp-updater.js
+++ b/src/main/services/ytdlp-updater.js
@@ -969,14 +969,6 @@ function isRedirect(response) {
 // =============================================================================
 
 /**
- * copy a directory tree, preserving permission bits
- * fs.promises.cp would do this in one line, but it still prints an
- * experimental warning on the node electron 28 ships
- * @param {string} source - directory to copy
- * @param {string} destination - directory to create
- * @returns {Promise<void>}
- */
-/**
  * put a prepared directory in place of the live one
  *
  * both directories live under the same userData parent, so the renames are
@@ -1024,6 +1016,14 @@ async function swapIn(preparedDir, installedDir) {
   await removeQuietly(retiredDir)
 }
 
+/**
+ * copy a directory tree, preserving permission bits
+ * fs.promises.cp would do this in one line, but it still prints an
+ * experimental warning on the node electron 28 ships
+ * @param {string} source - directory to copy
+ * @param {string} destination - directory to create
+ * @returns {Promise<void>}
+ */
 async function copyDirectory(source, destination) {
   await fsp.mkdir(destination, { recursive: true })
 

--- a/tests/pot-escalation.test.js
+++ b/tests/pot-escalation.test.js
@@ -18,7 +18,6 @@ const { EventEmitter } = require("events")
 
 const IPCHandlers = require("../src/main/ipc-handlers")
 const { ERROR_CODES } = require("../src/main/services/ytdlp-engine")
-const { PotInstaller } = require("../src/main/services/pot-installer")
 
 const settle = () => new Promise((resolve) => setImmediate(resolve))
 
@@ -185,19 +184,21 @@ describe("everything else leaves it alone", () => {
 
 /**
  * the sentence appended to the error is a promise, and it is only ours to make
- * when a payload can really arrive. no artifact is published yet, so the
- * shipping answer to "is a fix on its way" is no - and a user told to try again
- * in a minute would retry into the same wall for the life of the install.
+ * when a payload can really arrive. a platform we have not published one for
+ * cannot keep it, and a user told to try again in a minute would retry into the
+ * same wall for the life of the install.
  */
 describe("what the user is told", () => {
   const refused = () =>
     engineError(ERROR_CODES.BOT_DETECTION, "Sign in to confirm you're not a bot")
 
   test("no payload to fetch means no fix is promised", async () => {
+    const ensureInstalled = jest.fn()
     const { handlers } = createHandlers({
       infoError: refused(),
-      // the real one, with the real empty checksum table
-      potInstaller: new PotInstaller({ engine: { getUserDataPath: () => "/tmp" } })
+      // a platform nobody has published a payload for. the sentence is a
+      // promise, and there is nothing here that could keep it
+      potInstaller: { canInstall: () => false, ensureInstalled }
     })
 
     const response = await handlers.handleGetVideoInfo(null, {
@@ -207,7 +208,10 @@ describe("what the user is told", () => {
     await settle()
 
     expect(response.error.message).toBe("Sign in to confirm you're not a bot")
-    // the escalation itself still happens - it costs nothing and outlives this
+    // nothing is fetched either - there is no vouched-for payload to fetch
+    expect(ensureInstalled).not.toHaveBeenCalled()
+    // but the escalation itself still happens: it costs nothing, it outlives
+    // this session, and it arms the install for the day a payload does exist
     expect(handlers.engine.setPotEnabled).toHaveBeenCalledWith(true)
   })
 

--- a/tests/pot-installer.test.js
+++ b/tests/pot-installer.test.js
@@ -13,7 +13,12 @@ const os = require("os")
 const path = require("path")
 
 const { makeZip } = require("./helpers/zip-fixture")
-const { PotInstaller, VERSION_MARKER } = require("../src/main/services/pot-installer")
+const {
+  PotInstaller,
+  VERSION_MARKER,
+  POT_CHECKSUMS,
+  payloadAssetFor
+} = require("../src/main/services/pot-installer")
 
 let root
 let potDir
@@ -118,18 +123,38 @@ describe("nothing unverified is ever installed", () => {
     expect(fs.existsSync(potDir)).toBe(false)
   })
 
-  // the state this ships in: no artifact is published yet, so there is no
-  // digest to pin and the installer must decline rather than fetch whatever
-  // answers the url
+  // a platform we have not published and digested a payload for must decline
+  // rather than fetch whatever answers the url. every shipping platform now
+  // has a digest, so the unpublished case is reached by taking this one's away
   test("an asset nobody has vouched for is never fetched at all", async () => {
     const { installer, http } = createInstaller({ archive: makeZip(PAYLOAD_ENTRIES) })
     delete process.env.CLIPLY_POT_SHA256
 
-    const result = await installer.ensureInstalled()
+    const asset = payloadAssetFor()
+    const pinned = POT_CHECKSUMS[asset]
+    delete POT_CHECKSUMS[asset]
 
-    expect(result.installed).toBe(false)
-    expect(result.reason).toBe("no-payload-published")
-    expect(http.download).not.toHaveBeenCalled()
+    try {
+      expect(installer.canInstall()).toBe(false)
+
+      const result = await installer.ensureInstalled()
+
+      expect(result.installed).toBe(false)
+      expect(result.reason).toBe("no-payload-published")
+      expect(http.download).not.toHaveBeenCalled()
+    } finally {
+      POT_CHECKSUMS[asset] = pinned
+    }
+  })
+
+  // and the platforms we do ship are pinned, or the feature is dead on arrival
+  test("every platform we ship has a digest pinned", () => {
+    for (const platform of [
+      ["win32", "x64"],
+      ["darwin", "arm64"]
+    ]) {
+      expect(POT_CHECKSUMS[payloadAssetFor(...platform)]).toMatch(/^[0-9a-f]{64}$/)
+    }
   })
 
   test("an archive missing half the payload is refused", async () => {


### PR DESCRIPTION
Follow-up to #62. That PR built the machinery but shipped it inert — `POT_CHECKSUMS` was empty, so the installer declined every fetch. This pins the digests of the artifacts the payload workflow just published, which turns it on.

## What changed

- `POT_CHECKSUMS` — the two published payloads pinned
- `package.json` — 0.3.5 → **0.3.6**
- Two tests moved off the now-false assumption that nothing is published

## The digests are of the files as served

Taken from the release, not from the build. Both artifacts were downloaded back and hashed before being pinned — a digest captured on the runner only proves what left the runner.

```
7357586086aaf6b116af1acbc3051723c8e98104777764efe9a54dd2e233a240  pot-1.3.2-darwin-arm64.zip
57d9db2a1494becf7e434292cbec30fa05577661da31f2ed013bbc92bca932de  pot-1.3.2-win32-x64.zip
```

Both match the workflow's reported values exactly.

## Verified with nothing stubbed

Real https client, real published artifact, real checksum table, real extract and atomic swap into `userData`, then the resulting args handed to the real yt-dlp:

```
canInstall (checksum pinned?): true
downloading from the real release…
installed the PO token payload (pot-1.3.2-darwin-arm64.zip)
result: { installed: true, reason: 'installed' } (27.0s)
payload on disk: true
yt-dlp exit: 0
  | [pot:bgutil:script-deno] Generating a gvs PO Token for web client via bgutil script
  | dQw4w9WgXcQ: Retrieved a gvs PO Token for web client
minted: true
```

**That whole path had never run before** — every earlier check stubbed the network hop.

## The two tests

Both were pinned to the inert state. Neither was deleted, because what they guard still matters:

**`an asset nobody has vouched for is never fetched at all`** relied on the table being empty. It now removes this platform's digest to reach the unpublished case, and a companion test asserts both shipping platforms *do* have one — a table that quietly loses an entry is a feature dead on arrival. `POT_CHECKSUMS` is exported for this; there's no other seam.

**`no payload to fetch means no fix is promised`** relied on the same emptiness. It now uses an installer reporting `canInstall() === false`, which is the contract that was always under test, and additionally asserts nothing is fetched.

Mutation-checked: reverting the `canInstall()` guard turns the second one red.

## Behaviour after this merges

| | |
|---|---|
| Never refused (~86%) | Nothing changes. Same args, no download, no message |
| Refused | Flag persists for 7 days, ~50 MB payload downloads once, next attempt carries a token |
| Payload fetch fails | Exactly today's behaviour — flags omitted, nothing breaks |

749 tests pass; `tests/analytics.test.js` fails locally only because `posthog-node` isn't installed in this checkout (it passes in CI).

## Still outstanding

- No refresh path — `yt-dlp -U` updates the binary only and yt-dlp has no plugin-update facility, so drift against the self-updating engine stays ours. The installed version is recorded and `ensureInstalled()` is idempotent, so it can hang off the existing periodic pass.
- macOS + `canvas` under hardened runtime inside the signed app is unverified. CI proved Deno loads canvas on both platforms; the signed-app case is separate.
- Bumping `POT_VERSION` and the workflow's `version` input must happen together, with digests re-pinned by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
