### PR TITLE
feat: russian, picked from the system locale with an en · ru toggle

### DIFF
--- a/docs/superpowers/specs/2026-09-08-russian-localization-design.md
+++ b/docs/superpowers/specs/2026-09-08-russian-localization-design.md
@@ -1,0 +1,62 @@
+# Russian localization — Design
+
+Date: 2026-09-08
+Status: Approved
+
+## Why
+
+About 80% of active installs run with a Russian system locale (PostHog, `app_launched`
+by `locale`, Aug–Sep 2026). The UI is English only. The goal is a Russian user can use the
+main flows (paste a link, download, import cookies when YouTube blocks them) without a
+dictionary. Nothing about the layout, colours, fonts or motion changes.
+
+## Decisions
+
+| Decision | Choice | Why |
+| --- | --- | --- |
+| Mechanism | Two typed dictionary files, no library | ~150 strings, two languages. `tsc` fails on a missing translation, which JSON in react-i18next cannot do. No new dependency. |
+| Detection | `navigator.language` starts with `ru` → Russian, else English | Electron sets it from the same value as `app.getLocale()`. No IPC. |
+| Override | A `ru / en` text toggle beside the theme toggle, persisted in `localStorage` | An explicit choice beats the system locale. Rescues `uk` / `en-GB` users who read Russian. |
+| Fonts | Unchanged | Geist Mono was never loaded, so the OS mono fallback (has Cyrillic) is what everyone already sees. Space Grotesk has no Cyrillic; Cyrillic falls through to `system-ui`. Accepted for v1. |
+| Main-process error wording | Stays English in main; renderer localizes by error `code` | Main's text still feeds logs, analytics and GitHub issue bodies, which maintainers read in English. |
+| Native app menu | Localized in main from `app.getLocale()` | Small label table. Follows the OS, not the in-app toggle. |
+| About page | Stays English in v1 | Long prose, low traffic, not a main flow. |
+
+## Shape
+
+```
+src/main/renderer/src/lib/i18n/
+  en.ts      flat object: { "hero.tagline": "download stuff effortlessly", ... } as const
+  ru.ts      Record<keyof typeof en, string>  plus ruErrors: partial map of error code → {message, suggestion}
+  index.ts   useLocale store (zustand), t(key, params?), useT(), detectLocale(), localizeError()
+```
+
+- `t("cookies.count", { n })` interpolates `{n}`. A value containing `|` is a plural set
+  (`en`: `one|other`, `ru`: `one|few|many`) chosen with `Intl.PluralRules(locale).select(n)`.
+- `useLocale` initial state: `localStorage["cliply-locale"]` if `"en"` or `"ru"`, else
+  `detectLocale(navigator.language)`. Setting it writes `localStorage` and `<html lang>`.
+- `localizeError({ code, message, suggestion })` returns `ruErrors[code]` when the locale is
+  `ru` and the code is known, otherwise the object it was given. Same idea for the cookie
+  manager's `problem` and `note` sentences, which get a stable `code` alongside the text.
+- Product names stay Latin: YouTube, TikTok, Pinterest, cookies.txt, yt-dlp, Chrome, Firefox.
+- Voice: lowercase, plain, short, matching the English. No em-dashes in UI copy.
+
+## Surfaces
+
+In: hero (tagline, cookie hint, menu, footer), URL input and per-platform helper text,
+validation messages, cookie dialog (steps, notes, status, buttons, toasts, main's problem
+sentences), download card (tabs, labels, dropdowns, time range, buttons), progress bar,
+every toast in `toast-utils` and the download hooks, main's error wording, update
+notification, report dialog UI (not the issue body), support dialog, native app menu.
+
+Out: about page, `PRIVACY.md`, GitHub issue body, analytics property values.
+
+## Testing
+
+- Existing renderer tests keep asserting English; jsdom reports `en-US`.
+- `i18n.test.ts`: `ru` has every `en` key and no extras; interpolation; plural selection for
+  `ru` (1, 2, 5, 21) and `en`; `detectLocale` for `ru-RU`, `ru`, `en-GB`, `uk`; stored
+  override wins.
+- Russian renders of `CookieDialog` and the bot-detection toast, since those are the
+  surfaces the request is about.
+- Manual: run the app, flip the toggle, walk the three flows.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -48,6 +48,169 @@ const QUIT_FLUSH_TIMEOUT_MS = 2000
  */
 const ENGINE_CURRENT_REASONS = new Set(["up-to-date", "completed"])
 
+/**
+ * what the native menu says, in the two languages the app speaks
+ *
+ * this one surface follows app.getLocale() - the OS - rather than the in-app
+ * language toggle. the menu bar is the system's, it is built before a renderer
+ * exists to ask, and the alternative is an ipc round trip on every startup.
+ *
+ * sentence case here, unlike the lowercase in-app voice: these labels sit in
+ * the OS's own menu bar next to the OS's own words. product names stay latin.
+ */
+const MENU_TEXT = {
+  en: {
+    file: "File",
+    newDownload: "New Download",
+    openDownloads: "Open Downloads Folder",
+    quit: "Quit",
+
+    edit: "Edit",
+    undo: "Undo",
+    redo: "Redo",
+    cut: "Cut",
+    copy: "Copy",
+    paste: "Paste",
+
+    tools: "Tools",
+    checkUpdates: "Check for Updates",
+    videoEngine: "Video engine",
+    versionUnknown: "version unknown",
+    sendUsageData: "Send usage data",
+
+    view: "View",
+    reload: "Reload",
+    forceReload: "Force Reload",
+    devTools: "Toggle Developer Tools",
+    actualSize: "Actual Size",
+    zoomIn: "Zoom In",
+    zoomOut: "Zoom Out",
+    fullscreen: "Toggle Fullscreen",
+
+    window: "Window",
+    minimize: "Minimize",
+    close: "Close",
+    zoom: "Zoom",
+    bringAllToFront: "Bring All to Front",
+
+    help: "Help",
+    aboutCliply: "About Cliply",
+    systemHealth: "System Health",
+    reportIssue: "Report Issue",
+
+    // the macos app menu builds two of its labels around the app's own name
+    about: "About",
+    services: "Services",
+    hide: "Hide",
+    hideOthers: "Hide Others",
+    showAll: "Show All",
+
+    version: "Version",
+    aboutBlurb:
+      "Your fave little desktop app; powered by open source tools (>ᴗ•)",
+
+    // the boxes these menu items put up when something goes wrong
+    error: "Error",
+    updateCheckFailed: "Update Check Failed",
+    updateCheckFailedMessage: "Failed to check for updates.",
+    updateCheckFailedDetail: "Please try again later.",
+    updateUnavailable: "Update Check Unavailable",
+    updateUnavailableMessage: "Update checking is not available.",
+    updateUnavailableDetail:
+      "Updates are only available in production builds.",
+    prefNotSaved: "Couldn't save that preference",
+    prefNotSavedMessage: "Your analytics preference could not be saved.",
+    prefNotSavedDetail: "Please try again.",
+    healthCheckFailed: "Failed to check system health.",
+
+    healthHealthy: "System Status: Healthy",
+    healthError: "System Status: Error",
+    healthDownloader: "Downloader",
+    healthUnknown: "Unknown",
+    healthFound: "Found",
+    healthMissing: "Missing",
+    healthValid: "Valid",
+    healthInvalid: "Invalid",
+    healthActive: "Active downloads",
+    healthUptime: "Uptime",
+    healthMinutes: "minutes"
+  },
+  ru: {
+    file: "Файл",
+    newDownload: "Новая загрузка",
+    openDownloads: "Открыть папку загрузок",
+    quit: "Выход",
+
+    edit: "Правка",
+    undo: "Отменить",
+    redo: "Повторить",
+    cut: "Вырезать",
+    copy: "Копировать",
+    paste: "Вставить",
+
+    tools: "Инструменты",
+    checkUpdates: "Проверить обновления",
+    videoEngine: "Движок видео",
+    versionUnknown: "версия неизвестна",
+    sendUsageData: "Отправлять данные об использовании",
+
+    view: "Вид",
+    reload: "Перезагрузить",
+    forceReload: "Перезагрузить принудительно",
+    devTools: "Инструменты разработчика",
+    actualSize: "Исходный размер",
+    zoomIn: "Увеличить",
+    zoomOut: "Уменьшить",
+    fullscreen: "Полноэкранный режим",
+
+    window: "Окно",
+    minimize: "Свернуть",
+    close: "Закрыть",
+    zoom: "Масштаб",
+    bringAllToFront: "Все окна на передний план",
+
+    help: "Справка",
+    aboutCliply: "О Cliply",
+    systemHealth: "Состояние системы",
+    reportIssue: "Сообщить о проблеме",
+
+    about: "О",
+    services: "Службы",
+    hide: "Скрыть",
+    hideOthers: "Скрыть остальные",
+    showAll: "Показать все",
+
+    version: "Версия",
+    aboutBlurb:
+      "Ваше любимое маленькое приложение; работает на инструментах с открытым кодом (>ᴗ•)",
+
+    error: "Ошибка",
+    updateCheckFailed: "Не удалось проверить обновления",
+    updateCheckFailedMessage: "Не удалось проверить наличие обновлений.",
+    updateCheckFailedDetail: "Попробуйте позже.",
+    updateUnavailable: "Проверка обновлений недоступна",
+    updateUnavailableMessage: "Проверка обновлений здесь не работает.",
+    updateUnavailableDetail:
+      "Обновления доступны только в установленной версии.",
+    prefNotSaved: "Не удалось сохранить настройку",
+    prefNotSavedMessage: "Настройку аналитики не удалось сохранить.",
+    prefNotSavedDetail: "Попробуйте ещё раз.",
+    healthCheckFailed: "Не удалось проверить состояние системы.",
+
+    healthHealthy: "Состояние системы: в порядке",
+    healthError: "Состояние системы: ошибка",
+    healthDownloader: "Загрузчик",
+    healthUnknown: "неизвестно",
+    healthFound: "найден",
+    healthMissing: "отсутствует",
+    healthValid: "рабочие",
+    healthInvalid: "нерабочие",
+    healthActive: "Активные загрузки",
+    healthUptime: "Время работы",
+    healthMinutes: "мин."
+  }
+}
+
 class CliplyApp {
   constructor() {
     this.mainWindow = null
@@ -86,7 +249,10 @@ class CliplyApp {
       // setup app event handlers
       this.setupAppEvents()
 
-      // create menu
+      // create menu. after ready, because the menu is labelled from
+      // app.getLocale(), which answers with an empty string before it - and
+      // services can finish first on a fast machine
+      await app.whenReady()
       this.createMenu()
 
       // setup auto-updater in production
@@ -894,12 +1060,29 @@ class CliplyApp {
     // an update lands, and neither moment can wait on a --version probe
     const engineVersion = this.services.ytdlpEngine.getKnownVersion()
 
+    // the OS's language, not the in-app toggle. both callers run after ready,
+    // where getLocale() has settled - and a locale we cannot read leaves an
+    // english menu, which is better than an initialisation that aborts here
+    let locale = ""
+    try {
+      locale = app.getLocale()
+    } catch (error) {
+      console.error("Could not read the OS locale:", error)
+    }
+
+    const T =
+      MENU_TEXT[
+        typeof locale === "string" && locale.toLowerCase().startsWith("ru")
+          ? "ru"
+          : "en"
+      ]
+
     const template = [
       {
-        label: "File",
+        label: T.file,
         submenu: [
           {
-            label: "New Download",
+            label: T.newDownload,
             accelerator: "CmdOrCtrl+N",
             click: () => {
               if (this.mainWindow) {
@@ -909,7 +1092,7 @@ class CliplyApp {
           },
           { type: "separator" },
           {
-            label: "Open Downloads Folder",
+            label: T.openDownloads,
             accelerator: "CmdOrCtrl+D",
             click: async () => {
               try {
@@ -923,7 +1106,7 @@ class CliplyApp {
           },
           { type: "separator" },
           {
-            label: "Quit",
+            label: T.quit,
             accelerator: process.platform === "darwin" ? "Cmd+Q" : "Ctrl+Q",
             click: () => {
               app.quit()
@@ -932,21 +1115,21 @@ class CliplyApp {
         ]
       },
       {
-        label: "Edit",
+        label: T.edit,
         submenu: [
-          { label: "Undo", accelerator: "CmdOrCtrl+Z", role: "undo" },
-          { label: "Redo", accelerator: "Shift+CmdOrCtrl+Z", role: "redo" },
+          { label: T.undo, accelerator: "CmdOrCtrl+Z", role: "undo" },
+          { label: T.redo, accelerator: "Shift+CmdOrCtrl+Z", role: "redo" },
           { type: "separator" },
-          { label: "Cut", accelerator: "CmdOrCtrl+X", role: "cut" },
-          { label: "Copy", accelerator: "CmdOrCtrl+C", role: "copy" },
-          { label: "Paste", accelerator: "CmdOrCtrl+V", role: "paste" }
+          { label: T.cut, accelerator: "CmdOrCtrl+X", role: "cut" },
+          { label: T.copy, accelerator: "CmdOrCtrl+C", role: "copy" },
+          { label: T.paste, accelerator: "CmdOrCtrl+V", role: "paste" }
         ]
       },
       {
-        label: "Tools",
+        label: T.tools,
         submenu: [
           {
-            label: "Check for Updates",
+            label: T.checkUpdates,
             click: async () => {
               try {
                 if (this.ipcHandlers) {
@@ -958,25 +1141,25 @@ class CliplyApp {
                     console.error("Update check failed:", result.error?.message)
                     dialog.showMessageBox(this.mainWindow, {
                       type: "error",
-                      title: "Update Check Failed",
-                      message: "Failed to check for updates.",
+                      title: T.updateCheckFailed,
+                      message: T.updateCheckFailedMessage,
                       detail:
-                        result.error?.message || "Please try again later.",
+                        result.error?.message || T.updateCheckFailedDetail,
                       buttons: ["OK"]
                     })
                   }
                 } else {
                   dialog.showMessageBox(this.mainWindow, {
                     type: "warning",
-                    title: "Update Check Unavailable",
-                    message: "Update checking is not available.",
-                    detail: "Updates are only available in production builds.",
+                    title: T.updateUnavailable,
+                    message: T.updateUnavailableMessage,
+                    detail: T.updateUnavailableDetail,
                     buttons: ["OK"]
                   })
                 }
               } catch (error) {
                 console.error("Manual update check failed:", error)
-                dialog.showErrorBox("Error", "Failed to check for updates.")
+                dialog.showErrorBox(T.error, T.updateCheckFailedMessage)
               }
             }
           },
@@ -992,8 +1175,8 @@ class CliplyApp {
             // failed probe leaves us with no version for the whole run, and
             // guessing one would be worse than admitting it
             label: engineVersion
-              ? `Video engine: yt-dlp ${engineVersion}`
-              : "Video engine: version unknown",
+              ? `${T.videoEngine}: yt-dlp ${engineVersion}`
+              : `${T.videoEngine}: ${T.versionUnknown}`,
             enabled: false
           },
           { type: "separator" },
@@ -1002,7 +1185,7 @@ class CliplyApp {
             // install id and a city derived from the ip, which is pseudonymous
             // - and this label is read far more often than PRIVACY.md, so it
             // is where the word would do its damage
-            label: "Send usage data",
+            label: T.sendUsageData,
             type: "checkbox",
             checked: this.services.analytics.isEnabled(),
             click: async (menuItem) => {
@@ -1037,9 +1220,9 @@ class CliplyApp {
                 menuItem.checked = this.services.analytics.isEnabled()
                 dialog.showMessageBox(this.mainWindow, {
                   type: "error",
-                  title: "Couldn't save that preference",
-                  message: "Your analytics preference could not be saved.",
-                  detail: result.error || "Please try again.",
+                  title: T.prefNotSaved,
+                  message: T.prefNotSavedMessage,
+                  detail: result.error || T.prefNotSavedDetail,
                   buttons: ["OK"]
                 })
               }
@@ -1048,94 +1231,98 @@ class CliplyApp {
         ]
       },
       {
-        label: "View",
+        label: T.view,
         submenu: [
-          { label: "Reload", accelerator: "CmdOrCtrl+R", role: "reload" },
+          { label: T.reload, accelerator: "CmdOrCtrl+R", role: "reload" },
           {
-            label: "Force Reload",
+            label: T.forceReload,
             accelerator: "CmdOrCtrl+Shift+R",
             role: "forceReload"
           },
           {
-            label: "Toggle Developer Tools",
+            label: T.devTools,
             accelerator: "F12",
             role: "toggleDevTools"
           },
           { type: "separator" },
           {
-            label: "Actual Size",
+            label: T.actualSize,
             accelerator: "CmdOrCtrl+0",
             role: "resetZoom"
           },
-          { label: "Zoom In", accelerator: "CmdOrCtrl+Plus", role: "zoomIn" },
-          { label: "Zoom Out", accelerator: "CmdOrCtrl+-", role: "zoomOut" },
+          { label: T.zoomIn, accelerator: "CmdOrCtrl+Plus", role: "zoomIn" },
+          { label: T.zoomOut, accelerator: "CmdOrCtrl+-", role: "zoomOut" },
           { type: "separator" },
           {
-            label: "Toggle Fullscreen",
+            label: T.fullscreen,
             accelerator: "F11",
             role: "togglefullscreen"
           }
         ]
       },
       {
-        label: "Window",
+        label: T.window,
         submenu: [
-          { label: "Minimize", accelerator: "CmdOrCtrl+M", role: "minimize" },
-          { label: "Close", accelerator: "CmdOrCtrl+W", role: "close" }
+          { label: T.minimize, accelerator: "CmdOrCtrl+M", role: "minimize" },
+          { label: T.close, accelerator: "CmdOrCtrl+W", role: "close" }
         ]
       },
       {
-        label: "Help",
+        label: T.help,
         submenu: [
           {
-            label: "About Cliply",
+            label: T.aboutCliply,
             click: () => {
               dialog.showMessageBox(this.mainWindow, {
                 type: "info",
-                title: "About Cliply",
+                title: T.aboutCliply,
                 message: "Cliply Desktop",
-                detail: `Version: ${getAppVersion()}\n\nYour fave little desktop app; powered by open source tools (>ᴗ•)`,
+                detail: `${T.version}: ${getAppVersion()}\n\n${T.aboutBlurb}`,
                 buttons: ["OK"]
               })
             }
           },
           {
-            label: "System Health",
+            label: T.systemHealth,
             click: async () => {
               try {
                 if (this.ipcHandlers) {
                   const health = await this.ipcHandlers.handleSystemHealth()
 
                   const message = health.success
-                    ? `System Status: Healthy\n\nDownloader: ${
-                        health.data.engine.version || "Unknown"
+                    ? `${T.healthHealthy}\n\n${T.healthDownloader}: ${
+                        health.data.engine.version || T.healthUnknown
                       }\nFFmpeg: ${
-                        health.data.engine.ffmpeg ? "Found" : "Missing"
+                        health.data.engine.ffmpeg
+                          ? T.healthFound
+                          : T.healthMissing
                       }\nCookies: ${
-                        health.data.cookies.hasValid ? "Valid" : "Invalid"
-                      }\nActive downloads: ${
+                        health.data.cookies.hasValid
+                          ? T.healthValid
+                          : T.healthInvalid
+                      }\n${T.healthActive}: ${
                         health.data.downloads.active
-                      }\nUptime: ${Math.floor(
+                      }\n${T.healthUptime}: ${Math.floor(
                         health.data.performance.uptime / 60
-                      )} minutes`
-                    : `System Status: Error\n\n${health.error.message}`
+                      )} ${T.healthMinutes}`
+                    : `${T.healthError}\n\n${health.error.message}`
 
                   dialog.showMessageBox(this.mainWindow, {
                     type: health.success ? "info" : "error",
-                    title: "System Health",
+                    title: T.systemHealth,
                     message,
                     buttons: ["OK"]
                   })
                 }
               } catch (error) {
                 console.error("System health check failed:", error)
-                dialog.showErrorBox("Error", "Failed to check system health.")
+                dialog.showErrorBox(T.error, T.healthCheckFailed)
               }
             }
           },
           { type: "separator" },
           {
-            label: "Report Issue",
+            label: T.reportIssue,
             click: () => {
               shell.openExternal("https://github.com/Cliply/Cliply/issues")
             }
@@ -1149,33 +1336,33 @@ class CliplyApp {
       template.unshift({
         label: app.getName(),
         submenu: [
-          { label: "About " + app.getName(), role: "about" },
+          { label: T.about + " " + app.getName(), role: "about" },
           { type: "separator" },
-          { label: "Services", role: "services", submenu: [] },
+          { label: T.services, role: "services", submenu: [] },
           { type: "separator" },
           {
-            label: "Hide " + app.getName(),
+            label: T.hide + " " + app.getName(),
             accelerator: "Command+H",
             role: "hide"
           },
           {
-            label: "Hide Others",
+            label: T.hideOthers,
             accelerator: "Command+Shift+H",
             role: "hideothers"
           },
-          { label: "Show All", role: "unhide" },
+          { label: T.showAll, role: "unhide" },
           { type: "separator" },
-          { label: "Quit", accelerator: "Command+Q", click: () => app.quit() }
+          { label: T.quit, accelerator: "Command+Q", click: () => app.quit() }
         ]
       })
 
       // window menu
       template[5].submenu = [
-        { label: "Close", accelerator: "CmdOrCtrl+W", role: "close" },
-        { label: "Minimize", accelerator: "CmdOrCtrl+M", role: "minimize" },
-        { label: "Zoom", role: "zoom" },
+        { label: T.close, accelerator: "CmdOrCtrl+W", role: "close" },
+        { label: T.minimize, accelerator: "CmdOrCtrl+M", role: "minimize" },
+        { label: T.zoom, role: "zoom" },
         { type: "separator" },
-        { label: "Bring All to Front", role: "front" }
+        { label: T.bringAllToFront, role: "front" }
       ]
     }
 

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -118,48 +118,46 @@ function normalizeTimeRange(range) {
  *     rotated the session away. yt-dlp warns about exactly this, and since
  *     --cookies writes the jar back it is our own copy that lost the marker
  */
-function cookieJarProblem({
-  total,
-  youtube,
-  expired,
-  hasSid,
-  signedIn,
-  loadError
-}) {
+const JAR_PROBLEMS = {
+  JAR_MALFORMED: "that file is malformed, export a fresh one instead of editing it",
+  JAR_NOT_COOKIE_FILE: "that isn't a cookies.txt file, export it again",
+  JAR_NOTHING_IMPORTED: "nothing imported yet",
+  JAR_NO_YOUTUBE: "no youtube cookies in that file",
+  JAR_EXPIRED: "your cookies expired, grab a fresh export",
+  JAR_SESSION_ENDED: "youtube ended this session, export your cookies again",
+  JAR_NEVER_SIGNED_IN:
+    "these cookies aren't from a signed-in session, sign in first then export",
+  JAR_UNUSABLE: "no usable youtube cookies"
+}
+
+/**
+ * which of the sentences above a jar has earned
+ *
+ * the code travels to the renderer beside the sentence, so a russian install
+ * can say the same thing without matching english prose - and the english stays
+ * the one wording the logs and issue bodies carry.
+ */
+function cookieJarProblemCode({ total, youtube, expired, hasSid, signedIn, loadError }) {
   // checked first: a jar yt-dlp refuses whole inspects as zero of everything,
   // and "no cookies imported" is the wrong thing to say about a file that is
   // sitting there full of them and taking every download down with it
-  if (loadError === JAR_DOMAIN_FLAG) {
-    return "that file is malformed, export a fresh one instead of editing it"
-  }
-
-  if (loadError) {
-    return "that isn't a cookies.txt file, export it again"
-  }
-
-  if (total === 0) {
-    return "nothing imported yet"
-  }
-
-  if (youtube === 0) {
-    return "no youtube cookies in that file"
-  }
+  if (loadError === JAR_DOMAIN_FLAG) return "JAR_MALFORMED"
+  if (loadError) return "JAR_NOT_COOKIE_FILE"
+  if (total === 0) return "JAR_NOTHING_IMPORTED"
+  if (youtube === 0) return "JAR_NO_YOUTUBE"
 
   // any expiry at all is worth saying so, rather than only a jar where every
   // last cookie is dead. an export whose login expired alongside a still-live
   // PREF used to fall through to "you were never signed in", which sends the
   // user to fix something that was never wrong
-  if (!signedIn && expired > 0) {
-    return "your cookies expired, grab a fresh export"
-  }
+  if (!signedIn && expired > 0) return "JAR_EXPIRED"
+  if (!signedIn) return hasSid ? "JAR_SESSION_ENDED" : "JAR_NEVER_SIGNED_IN"
 
-  if (!signedIn) {
-    return hasSid
-      ? "youtube ended this session, export your cookies again"
-      : "these cookies aren't from a signed-in session, sign in first then export"
-  }
+  return "JAR_UNUSABLE"
+}
 
-  return "no usable youtube cookies"
+function cookieJarProblem(inspection) {
+  return JAR_PROBLEMS[cookieJarProblemCode(inspection)]
 }
 
 /**
@@ -1203,7 +1201,11 @@ class IPCHandlers {
       // generic "Failed to import cookie file"
       return this.createError(
         error.message || "couldn't import that cookie file",
-        "export cookies.txt with a browser extension, then pick that file."
+        "export cookies.txt with a browser extension, then pick that file.",
+        // the manager's refusal code, so the renderer can say the same thing in
+        // russian. anything else - a full disk, a permission error - has none,
+        // and falls back to createError's placeholder
+        error.code || "GENERAL_ERROR"
       )
     }
   }
@@ -1226,13 +1228,15 @@ class IPCHandlers {
       const inspection = await this.cookieManager.inspectCookieFile()
 
       if (!inspection.usable) {
-        const note = cookieJarProblem(inspection)
+        const noteCode = cookieJarProblemCode(inspection)
+        const note = JAR_PROBLEMS[noteCode]
 
         await this.cookieManager.updateStatus({
           lastTest: new Date().toISOString(),
           cookiesLoaded: false,
           extractionCheck: "skipped",
-          note
+          note,
+          noteCode
         })
 
         return this.createSuccess({
@@ -1240,13 +1244,14 @@ class IPCHandlers {
           extractionCheck: "skipped",
           rejected: false,
           note,
+          noteCode,
           status: await this.cookieManager.getStatus(),
           hasValidCookies: false
         })
       }
 
       // probe with the cookie file forced on, so the result depends on it
-      const { extractionCheck, note } = await this.probeCookies(
+      const { extractionCheck, note, noteCode } = await this.probeCookies(
         this.cookieManager.getCookieFilePath()
       )
 
@@ -1254,7 +1259,8 @@ class IPCHandlers {
         lastTest: new Date().toISOString(),
         cookiesLoaded: true,
         extractionCheck,
-        note
+        note,
+        noteCode
       })
 
       return this.createSuccess({
@@ -1267,6 +1273,7 @@ class IPCHandlers {
         // turned them down
         rejected: extractionCheck === "rejected",
         note,
+        noteCode,
         status: await this.cookieManager.getStatus(),
         hasValidCookies: this.cookieManager.hasValidCookies()
       })
@@ -1283,8 +1290,13 @@ class IPCHandlers {
    * us nothing" rather than a verdict. anything else - a success, bot
    * detection, a network failure - is about the cookies, so it ends the walk.
    *
+   * every note carries a `noteCode` for the same reason the jar problems do:
+   * the renderer translates by code, and the english stays what the logs read.
+   * the codes: PROBE_PASSED, PROBE_EMPTY, PROBE_REJECTED, PROBE_UNREACHABLE,
+   * PROBE_FAILED, PROBE_TARGETS_DOWN.
+   *
    * @param {string|null} cookieFile - the jar to force on for the probe
-   * @returns {Promise<Object>} {extractionCheck, note}
+   * @returns {Promise<Object>} {extractionCheck, note, noteCode}
    */
   async probeCookies(cookieFile) {
     let deadTargets = 0
@@ -1296,12 +1308,14 @@ class IPCHandlers {
         if (info && info.title) {
           return {
             extractionCheck: "passed",
+            noteCode: "PROBE_PASSED",
             note: "the download path worked with your cookies attached. that alone doesn't prove youtube accepted them."
           }
         }
 
         return {
           extractionCheck: "unknown",
+          noteCode: "PROBE_EMPTY",
           note: "the test video came back with nothing."
         }
       } catch (probeError) {
@@ -1316,6 +1330,7 @@ class IPCHandlers {
         if (probeError.code === ERROR_CODES.BOT_DETECTION) {
           return {
             extractionCheck: "rejected",
+            noteCode: "PROBE_REJECTED",
             note: "youtube still asked us to prove we're not a bot while sending your cookies, so they're expired or not being accepted."
           }
         }
@@ -1323,12 +1338,14 @@ class IPCHandlers {
         if (probeError.code === ERROR_CODES.NETWORK_ERROR) {
           return {
             extractionCheck: "unknown",
+            noteCode: "PROBE_UNREACHABLE",
             note: "couldn't reach youtube, so the cookies went untested."
           }
         }
 
         return {
           extractionCheck: "unknown",
+          noteCode: "PROBE_FAILED",
           note: `the test couldn't finish: ${probeError.message}`
         }
       }
@@ -1336,6 +1353,7 @@ class IPCHandlers {
 
     return {
       extractionCheck: "unknown",
+      noteCode: "PROBE_TARGETS_DOWN",
       note: `all ${deadTargets} of our test videos are down right now, so this says nothing about your cookies.`
     }
   }
@@ -1346,26 +1364,28 @@ class IPCHandlers {
       const status = await this.cookieManager.getStatus()
       const fileInfo = await this.cookieManager.getFileInfo()
       const usable = this.cookieManager.hasValidCookies()
+      // the sentence rather than the ingredients: cookieJarProblem already
+      // knows which way a jar is unusable, and a second copy of that in the
+      // renderer is the drift the shared parser exists to prevent. an
+      // unreadable file reports zero of everything, which is the "nothing
+      // imported" branch and the right thing to say
+      const problemCode = usable
+        ? null
+        : cookieJarProblemCode({
+            total: fileInfo.cookieCount,
+            youtube: fileInfo.youtubeCookieCount || 0,
+            expired: fileInfo.expiredCookieCount || 0,
+            hasSid: fileInfo.hasSid,
+            signedIn: fileInfo.signedIn,
+            loadError: fileInfo.loadError ?? null
+          })
 
       return this.createSuccess({
         status,
         fileInfo,
         hasValidCookies: usable,
-        // the sentence rather than the ingredients: cookieJarProblem already
-        // knows which way a jar is unusable, and a second copy of that in the
-        // renderer is the drift the shared parser exists to prevent. an
-        // unreadable file reports zero of everything, which is the "nothing
-        // imported" branch and the right thing to say
-        problem: usable
-          ? null
-          : cookieJarProblem({
-              total: fileInfo.cookieCount,
-              youtube: fileInfo.youtubeCookieCount || 0,
-              expired: fileInfo.expiredCookieCount || 0,
-              hasSid: fileInfo.hasSid,
-              signedIn: fileInfo.signedIn,
-              loadError: fileInfo.loadError ?? null
-            })
+        problem: problemCode && JAR_PROBLEMS[problemCode],
+        problemCode
       })
     } catch (error) {
       console.error("Get cookie status failed:", error.message)
@@ -1701,3 +1721,4 @@ module.exports = IPCHandlers
 // the wrong sentence sends the user to fix the wrong thing, so it is worth a
 // test even though nothing else imports it
 module.exports.cookieJarProblem = cookieJarProblem
+module.exports.cookieJarProblemCode = cookieJarProblemCode

--- a/src/main/ipc-handlers.js
+++ b/src/main/ipc-handlers.js
@@ -1203,9 +1203,12 @@ class IPCHandlers {
         error.message || "couldn't import that cookie file",
         "export cookies.txt with a browser extension, then pick that file.",
         // the manager's refusal code, so the renderer can say the same thing in
-        // russian. anything else - a full disk, a permission error - has none,
-        // and falls back to createError's placeholder
-        error.code || "GENERAL_ERROR"
+        // russian. only those cross: a full disk or a permission error carries a
+        // node code of its own (ENOSPC, EACCES), and forwarding that would make
+        // the field mean two things
+        typeof error.code === "string" && error.code.startsWith("COOKIES_")
+          ? error.code
+          : "GENERAL_ERROR"
       )
     }
   }

--- a/src/main/renderer/src/components/cookies/CookieDialog.test.tsx
+++ b/src/main/renderer/src/components/cookies/CookieDialog.test.tsx
@@ -11,6 +11,7 @@ import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 import { useCookieStore } from "@/lib/cookieStore"
+import { useLocale } from "@/lib/i18n"
 
 const getStatus = vi.fn()
 
@@ -27,7 +28,15 @@ vi.mock("@/lib/api", () => ({
     test: () => testCookies(),
     clear: () => clearCookies()
   },
-  systemApi: { openExternal: (...a: unknown[]) => openExternal(...(a as [])) }
+  systemApi: { openExternal: (...a: unknown[]) => openExternal(...(a as [])) },
+  // the dialog asks whether a refusal carried one of main's codes
+  CookieError: class CookieError extends Error {
+    code?: string
+    constructor(message: string, code?: string) {
+      super(message)
+      this.code = code
+    }
+  }
 }))
 const toastPlain = vi.fn()
 const toastWarning = vi.fn()
@@ -78,7 +87,11 @@ beforeEach(() => {
   openExternal.mockClear()
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  // every other test in this file asserts on english
+  useLocale.setState({ locale: "en" })
+})
 
 describe("CookieDialog", () => {
   test("a signed-in jar reports the count and drops the instructions", async () => {
@@ -412,6 +425,103 @@ describe("the row above the steps", () => {
     await waitFor(() => expect(screen.getByText(/signed in · 22 cookies/)).toBeTruthy())
     expect(screen.queryByText("here's how to import them")).toBeNull()
   })
+})
+
+/**
+ * this dialog is the reason the translation exists: a blocked russian user who
+ * cannot read the six steps has no way out of the block at all.
+ *
+ * main's own sentences are the interesting half. They stay english on the wire
+ * - the logs and issue bodies read them - and arrive with a code beside them,
+ * so the row below is translated without anyone matching english prose.
+ */
+describe("in russian", () => {
+  beforeEach(() => useLocale.setState({ locale: "ru" }))
+
+  test("the steps and the import button are readable", async () => {
+    getStatus.mockResolvedValue(status())
+
+    await open()
+
+    await waitFor(() =>
+      expect(screen.getByText("импортируйте этот файл здесь")).toBeTruthy()
+    )
+    expect(screen.getByText("импортировать cookies…")).toBeTruthy()
+    // the product names that stay latin whatever the locale
+    expect(screen.getByText("get cookies.txt LOCALLY")).toBeTruthy()
+  })
+
+  test("main's verdict is said in russian, by its code", async () => {
+    getStatus.mockResolvedValue(
+      status({
+        problem: "youtube ended this session, export your cookies again",
+        problemCode: "JAR_SESSION_ENDED",
+        fileInfo: { ...status().fileInfo, cookieCount: 12, youtubeCookieCount: 12, hasSid: true }
+      })
+    )
+
+    await open()
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("YouTube завершил эту сессию, экспортируйте cookies заново")
+      ).toBeTruthy()
+    )
+  })
+
+  // a code this dictionary has not caught up with must not blank the row
+  test("a code we do not know keeps main's english", async () => {
+    getStatus.mockResolvedValue(
+      status({
+        problem: "something new main learned to say",
+        problemCode: "JAR_SOMETHING_NEW",
+        fileInfo: { ...status().fileInfo, cookieCount: 12, youtubeCookieCount: 12 }
+      })
+    )
+
+    await open()
+
+    await waitFor(() =>
+      expect(screen.getByText("something new main learned to say")).toBeTruthy()
+    )
+  })
+
+  // the word stays latin and undeclined next to any number, because what is
+  // being counted is cookies rather than the one file holding them
+  test("the signed-in row counts in russian", async () => {
+    getStatus.mockResolvedValue(
+      status({
+        hasValidCookies: true,
+        fileInfo: { ...status().fileInfo, cookieCount: 22, youtubeCookieCount: 22, signedIn: true, valid: true }
+      })
+    )
+
+    await open()
+
+    await waitFor(() =>
+      expect(screen.getByText("вы вошли · 22 cookies")).toBeTruthy()
+    )
+  })
+})
+
+// and english still gets main's sentence untouched, which is the other half of
+// the same decision
+test("under english the status row is main's own text", async () => {
+  getStatus.mockResolvedValue(
+    status({
+      problem: "youtube ended this session, export your cookies again",
+      problemCode: "JAR_SESSION_ENDED",
+      fileInfo: { ...status().fileInfo, cookieCount: 12, youtubeCookieCount: 12, hasSid: true }
+    })
+  )
+
+  await open()
+
+  await waitFor(() =>
+    expect(
+      screen.getByText("youtube ended this session, export your cookies again")
+    ).toBeTruthy()
+  )
 })
 
 // "export the cookies" was a gesture people were expected to already know.

--- a/src/main/renderer/src/components/cookies/CookieDialog.tsx
+++ b/src/main/renderer/src/components/cookies/CookieDialog.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Check, Cookie, Copy, KeyRound } from "lucide-react"
-import { cookiesApi, systemApi, type CookieStatus } from "@/lib/api"
+import { CookieError, cookiesApi, systemApi, type CookieStatus } from "@/lib/api"
 import { useCookieStore } from "@/lib/cookieStore"
+import { localizeCode, t, useLocale } from "@/lib/i18n"
 import {
   Dialog,
   DialogContent,
@@ -19,8 +20,10 @@ import { cn } from "@/lib/utils"
 // than a shortcut
 const CHROME_EXTENSION =
   "https://chromewebstore.google.com/detail/get-cookiestxt-locally/cclelndahbckbenkjhflpdbgdldlbecc"
-const FIREFOX_EXTENSION =
-  "https://addons.mozilla.org/en-US/firefox/addon/cookies-txt/"
+// the chrome store localizes itself from the account; addons.mozilla.org takes
+// the language in the path and would otherwise land a russian reader on english
+const FIREFOX_EXTENSION = (locale: string) =>
+  `https://addons.mozilla.org/${locale === "ru" ? "ru" : "en-US"}/firefox/addon/cookies-txt/`
 const YTDLP_COOKIE_GUIDE =
   "https://github.com/yt-dlp/yt-dlp/wiki/Extractors#exporting-youtube-cookies"
 
@@ -41,13 +44,15 @@ function daysAgo(iso?: string | null): string | null {
   if (!Number.isFinite(then)) return null
 
   const days = Math.floor((Date.now() - then) / 86_400_000)
-  if (days <= 0) return "imported today"
-  if (days === 1) return "imported yesterday"
+  if (days <= 0) return t("cookies.importedToday")
+  if (days === 1) return t("cookies.importedYesterday")
 
-  return `imported ${days} days ago`
+  return t("cookies.importedDaysAgo", { n: days })
 }
 
 export function CookieDialog() {
+  // also the re-render when the locale flips, which every t() below needs
+  const locale = useLocale((s) => s.locale)
   const { isOpen, close } = useCookieStore()
   const [status, setStatus] = useState<CookieStatus | null>(null)
   const [busy, setBusy] = useState<"import" | "test" | "clear" | null>(null)
@@ -98,22 +103,29 @@ export function CookieDialog() {
         const next = await refresh()
 
         if (result.hasValidCookies) {
-          toast.success("cookies imported", {
-            description: "youtube will see you as signed in from now on."
+          toast.success(t("cookies.imported"), {
+            description: t("cookies.importedDesc")
           })
         } else {
           // an import that lands but is not a login used to say nothing at all,
           // which reads as the button doing nothing. main already worked out
           // which way it fell short
-          toast.warning("imported, but not signed in", {
-            description: next?.problem ?? "these cookies won't sign you in."
+          toast.warning(t("cookies.notSignedIn"), {
+            description: next?.problem
+              ? localizeCode(next.problemCode, next.problem)
+              : t("cookies.notSignedInDesc")
           })
         }
       }
     } catch (error) {
-      toast.error("couldn't import that file", {
+      toast.error(t("cookies.importFailed"), {
         description:
-          error instanceof Error ? error.message : "couldn't import cookies"
+          error instanceof Error
+            ? localizeCode(
+                error instanceof CookieError ? error.code : null,
+                error.message
+              )
+            : t("cookies.importFailedDesc")
       })
     } finally {
       setBusy(null)
@@ -129,17 +141,17 @@ export function CookieDialog() {
       // three outcomes, not two. titling this off cookiesLoaded alone put
       // "Cookies look fine" above a description explaining that YouTube had
       // just refused them
+      const note = localizeCode(result.noteCode, result.note)
+
       if (result.rejected) {
-        toast.warning("youtube turned these down", {
-          description: result.note
-        })
+        toast.warning(t("cookies.turnedDown"), { description: note })
       } else {
-        toast(result.cookiesLoaded ? "cookies look fine" : "cookies aren't usable", {
-          description: result.note
+        toast(t(result.cookiesLoaded ? "cookies.lookFine" : "cookies.notUsable"), {
+          description: note
         })
       }
     } catch (error) {
-      toast.error("couldn't test the cookies", {
+      toast.error(t("cookies.testFailed"), {
         description: error instanceof Error ? error.message : undefined
       })
     } finally {
@@ -155,11 +167,9 @@ export function CookieDialog() {
     } catch (error) {
       // a failure here means the jar is still on disk, which is the opposite
       // of what the screen would otherwise go on to show
-      toast.error("couldn't remove the cookies", {
+      toast.error(t("cookies.removeFailed"), {
         description:
-          error instanceof Error
-            ? error.message
-            : "they're still on this machine."
+          error instanceof Error ? error.message : t("cookies.removeFailedDesc")
       })
       await refresh()
     } finally {
@@ -179,8 +189,8 @@ export function CookieDialog() {
       window.setTimeout(() => setCopied(false), 1600)
     } catch {
       // clipboard is best-effort, and the address is on screen to type
-      toast.error("couldn't copy that", {
-        description: "type youtube.com/robots.txt into that tab instead."
+      toast.error(t("cookies.copyFailed"), {
+        description: t("cookies.copyFailedDesc")
       })
     }
   }
@@ -207,13 +217,11 @@ export function CookieDialog() {
               <Cookie className="h-4 w-4" />
             </span>
             <DialogTitle className="text-slate-900 dark:text-white">
-              youtube cookies
+              {t("cookies.title")}
             </DialogTitle>
           </div>
           <DialogDescription className="text-slate-500 dark:text-slate-400">
-            youtube sometimes decides this machine looks like a bot, usually
-            because of your network rather than anything you did. a cookie file
-            from your own browser is how you tell it otherwise.
+            {t("cookies.description")}
           </DialogDescription>
         </DialogHeader>
 
@@ -224,17 +232,15 @@ export function CookieDialog() {
           <KeyRound className="mt-0.5 h-3.5 w-3.5 shrink-0 text-cyan-600 dark:text-cyan-400" />
           <div className="space-y-1">
             <p className="text-slate-600 dark:text-slate-300">
-              you sign in to youtube in your own browser, never to cliply.
-              everything stays on this device, we never upload any of it, and
-              you can delete it whenever you want.
+              {t("cookies.privacy")}
             </p>
             {/* borrowed credibility. "some app wants my youtube session" is a
                 reasonable thing to balk at, and the answer is that this is the
                 documented way the tool underneath asks for them */}
             <p className="text-xs text-slate-400 dark:text-slate-500">
-              it&apos;s the standard process yt-dlp recommends.{" "}
+              {t("cookies.ytdlpCredit")}{" "}
               <button className={linkClass} onClick={openLink(YTDLP_COOKIE_GUIDE)}>
-                read their guide
+                {t("cookies.readGuide")}
               </button>
             </p>
           </div>
@@ -259,10 +265,12 @@ export function CookieDialog() {
             )}
             <span className="text-slate-700 dark:text-slate-200">
               {signedIn
-                ? `signed in · ${status?.fileInfo.youtubeCookieCount ?? 0} cookies`
+                ? `${t("cookies.signedIn")} · ${t("cookies.count", {
+                    n: status?.fileInfo.youtubeCookieCount ?? 0
+                  })}`
                 : untouched
-                  ? "here's how to import them"
-                  : status?.problem}
+                  ? t("cookies.howTo")
+                  : localizeCode(status?.problemCode, status?.problem ?? "")}
             </span>
             {imported && daysAgo(status?.status?.lastImport) && (
               <span className="ml-auto shrink-0 text-xs text-slate-400 dark:text-slate-500">
@@ -276,12 +284,13 @@ export function CookieDialog() {
               that an import ever happened. that reads as "it deleted them" */}
           {imported && !signedIn && (
             <p className="text-sm text-slate-600 dark:text-slate-300">
-              your file is still here
+              {t("cookies.stillHere")}
               {status?.fileInfo.youtubeCookieCount
-                ? ` (${status.fileInfo.youtubeCookieCount} cookies)`
+                ? ` (${t("cookies.count", {
+                    n: status.fileInfo.youtubeCookieCount
+                  })})`
                 : ""}
-              , it just stopped working. nothing got deleted. grab a fresh
-              export and import it over the top.
+              {t("cookies.stillHereRest")}
             </p>
           )}
 
@@ -296,29 +305,26 @@ export function CookieDialog() {
                   which account to use */}
               <ol className="space-y-3 text-sm">
                 <Step n={1}>
-                  install{" "}
+                  {t("cookies.step1")}{" "}
                   <button className={linkClass} onClick={openLink(CHROME_EXTENSION)}>
                     get cookies.txt LOCALLY
                   </button>{" "}
-                  (chrome) or{" "}
-                  <button className={linkClass} onClick={openLink(FIREFOX_EXTENSION)}>
+                  {t("cookies.step1or")}{" "}
+                  <button
+                    className={linkClass}
+                    onClick={openLink(FIREFOX_EXTENSION(locale))}
+                  >
                     cookies.txt
                   </button>{" "}
-                  (firefox)
+                  {t("cookies.step1firefox")}
                 </Step>
 
-                <Step
-                  n={2}
-                  note="use a spare account if you have one. youtube has been known to ban accounts it catches using downloaders."
-                >
-                  open youtube in your browser and sign in
+                <Step n={2} note={t("cookies.step2note")}>
+                  {t("cookies.step2")}
                 </Step>
 
-                <Step
-                  n={3}
-                  note="parks the tab somewhere youtube isn't handing out fresh cookies."
-                >
-                  in that same tab, go to{" "}
+                <Step n={3} note={t("cookies.step3note")}>
+                  {t("cookies.step3")}{" "}
                   <button
                     onClick={copyRobots}
                     className="inline-flex items-center gap-1.5 rounded bg-slate-200/70 px-1.5 py-0.5 align-middle text-xs text-cyan-700 transition-colors hover:bg-slate-200 dark:bg-slate-900/60 dark:text-cyan-400 dark:hover:bg-slate-900"
@@ -331,7 +337,7 @@ export function CookieDialog() {
                     )}
                   </button>{" "}
                   <span className="text-xs text-slate-400 dark:text-slate-500">
-                    {copied ? "copied, paste it there" : "click to copy"}
+                    {t(copied ? "cookies.copied" : "cookies.copyHint")}
                   </span>
                 </Step>
 
@@ -339,38 +345,34 @@ export function CookieDialog() {
                     a gesture. it is a toolbar icon and a button, and saying so
                     is the difference between following the steps and giving up
                     on step 4 */}
-                <Step
-                  n={4}
-                  note="up by your address bar, sometimes under the puzzle piece. saves a .txt to your downloads."
-                >
-                  click the extension&apos;s icon, then hit <Em>export</Em>
+                <Step n={4} note={t("cookies.step4note")}>
+                  {t("cookies.step4")} <Em>{t("cookies.step4export")}</Em>
                 </Step>
 
                 {/* the trim took the point out with the words: "youtube keeps
                     refreshing cookies on open tabs" says what youtube does and
                     leaves the reader to work out why they should care. the
                     consequence is the whole reason the step exists */}
-                <Step
-                  n={5}
-                  note="youtube keeps refreshing cookies on open youtube tabs, and every refresh ages your export. closing it is what makes these last."
-                >
-                  close that youtube tab
+                <Step n={5} note={t("cookies.step5note")}>
+                  {t("cookies.step5")}
                 </Step>
 
-                <Step n={6}>import that file here</Step>
+                <Step n={6}>{t("cookies.step6")}</Step>
               </ol>
             </>
           )}
 
           <div className="flex items-center gap-2">
             <Button ref={importRef} onClick={handleImport} disabled={busy !== null}>
-              {busy === "import"
-                ? "importing…"
-                : signedIn
-                  ? "replace…"
-                  : imported
-                    ? "try again…"
-                    : "import cookies…"}
+              {t(
+                busy === "import"
+                  ? "cookies.importing"
+                  : signedIn
+                    ? "cookies.replace"
+                    : imported
+                      ? "cookies.tryAgain"
+                      : "cookies.import"
+              )}
             </Button>
 
             {imported && (
@@ -379,7 +381,7 @@ export function CookieDialog() {
                 onClick={handleTest}
                 disabled={busy !== null}
               >
-                {busy === "test" ? "testing…" : "test"}
+                {t(busy === "test" ? "cookies.testing" : "cookies.test")}
               </Button>
             )}
 
@@ -390,7 +392,7 @@ export function CookieDialog() {
                 onClick={handleClear}
                 disabled={busy !== null}
               >
-                remove
+                {t("cookies.remove")}
               </Button>
             )}
           </div>
@@ -399,14 +401,7 @@ export function CookieDialog() {
               answers actually is. saying it twice in one dialog reads as
               insisting */}
           <p className="text-xs text-slate-400 dark:text-slate-500">
-            {signedIn ? (
-              "youtube rotates these out eventually. when it does, cliply will say so right here."
-            ) : (
-              <>
-                nothing here is sent anywhere. the file only ever goes to
-                youtube, from your own machine.
-              </>
-            )}
+            {t(signedIn ? "cookies.footerSignedIn" : "cookies.footer")}
           </p>
         </div>
       </DialogContent>

--- a/src/main/renderer/src/components/hero/HeroSection.test.tsx
+++ b/src/main/renderer/src/components/hero/HeroSection.test.tsx
@@ -7,10 +7,13 @@
 // chrome and is the only pre-emptive one, so it is worth a test that it still
 // opens the thing it advertises.
 
-import { cleanup, render, screen } from "@testing-library/react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 import { useCookieStore } from "@/lib/cookieStore"
+import { en } from "@/lib/i18n/en"
+import { ru } from "@/lib/i18n/ru"
+import { useLocale } from "@/lib/i18n"
 
 vi.mock("@/lib/api", () => ({
   updaterApi: { checkForUpdates: vi.fn() },
@@ -120,5 +123,46 @@ describe("the menu", () => {
     expect(hrefs.github).toBe("https://github.com/Cliply/Cliply/")
     // the label changed, the route did not
     expect(hrefs.about).toBe("/disclaimer")
+  })
+})
+
+// every test above renders english, because jsdom reports en-US and that is
+// what an english user still sees. this is the other half
+describe("in russian", () => {
+  afterEach(() => useLocale.setState({ locale: "en" }))
+
+  const pressed = () => ({
+    en: screen.getByText("en").getAttribute("aria-pressed"),
+    ru: screen.getByText("ru").getAttribute("aria-pressed")
+  })
+
+  test("the hero speaks it when the machine already does", async () => {
+    useLocale.setState({ locale: "ru" })
+    const { HeroSection } = await import("./HeroSection")
+    render(<HeroSection />)
+
+    expect(screen.getByText(new RegExp(ru["hero.tagline"]))).toBeTruthy()
+    expect(pressed()).toEqual({ en: "false", ru: "true" })
+  })
+
+  // clicked rather than pre-set, and in both directions: setting the store
+  // before the first render would still pass with `useT`'s subscription torn
+  // out, or with the toggle wired to nothing
+  test("the toggle switches a mounted hero, and switches it back", async () => {
+    const { HeroSection } = await import("./HeroSection")
+    render(<HeroSection />)
+
+    expect(screen.getByText(new RegExp(en["hero.tagline"]))).toBeTruthy()
+
+    fireEvent.click(screen.getByText("ru"))
+
+    expect(screen.getByText(new RegExp(ru["hero.tagline"]))).toBeTruthy()
+    expect(screen.queryByText(new RegExp(en["hero.tagline"]))).toBeNull()
+    expect(pressed()).toEqual({ en: "false", ru: "true" })
+
+    fireEvent.click(screen.getByText("en"))
+
+    expect(screen.getByText(new RegExp(en["hero.tagline"]))).toBeTruthy()
+    expect(pressed()).toEqual({ en: "true", ru: "false" })
   })
 })

--- a/src/main/renderer/src/components/hero/HeroSection.tsx
+++ b/src/main/renderer/src/components/hero/HeroSection.tsx
@@ -1,7 +1,9 @@
+import { LocaleToggle } from "@/components/ui/locale-toggle"
 import { MenuVertical } from "@/components/ui/menu-vertical"
 import { ModeToggle } from "@/components/ui/mode-toggle"
 import { updaterApi } from "@/lib/api"
 import { cookieActions } from "@/lib/cookieStore"
+import { useT } from "@/lib/i18n"
 import { motion } from "framer-motion"
 import { toast } from "sonner"
 import { useAppStore } from "@/lib/store"
@@ -9,14 +11,17 @@ import { SearchCard } from "./SearchCard"
 
 export function HeroSection() {
   const { selectedPlatform } = useAppStore()
+  const t = useT()
   const handleCheckForUpdates = async () => {
     try {
       await updaterApi.checkForUpdates()
     } catch (error) {
       console.error("Failed to check for updates:", error)
-      toast.error("Check Failed", {
+      toast.error(t("hero.updateCheckFailed"), {
         description:
-          error instanceof Error ? error.message : "Failed to check for updates"
+          error instanceof Error
+            ? error.message
+            : t("hero.updateCheckFailedBody")
       })
     }
   }
@@ -36,11 +41,11 @@ export function HeroSection() {
             // opens has titled itself "about" the whole time. The menu was the
             // only place still calling it the disclaimer.
             {
-              label: "about",
+              label: t("menu.about"),
               href: "/disclaimer"
             },
             {
-              label: "update",
+              label: t("menu.update"),
               onClick: handleCheckForUpdates
             },
             // cookies came out of here once the line in the top chrome started
@@ -49,12 +54,12 @@ export function HeroSection() {
             // the users who already went looking, and two doors to the same
             // room made the menu longer for nothing
             {
-              label: "donate",
+              label: t("menu.donate"),
               href: "https://buymeacoffee.com/itssdevk",
               external: true
             },
             {
-              label: "github",
+              label: t("menu.github"),
               href: "https://github.com/Cliply/Cliply/",
               external: true
             }
@@ -64,8 +69,9 @@ export function HeroSection() {
         />
       </div>
 
-      {/* Mode toggle - top right */}
-      <div className="absolute top-6 right-6 z-20">
+      {/* Language and mode toggles - top right */}
+      <div className="absolute top-6 right-6 z-20 flex items-center gap-2">
+        <LocaleToggle />
         <ModeToggle />
       </div>
 
@@ -93,7 +99,7 @@ export function HeroSection() {
               'Geist Mono, ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
           }}
         >
-          having trouble with downloads? try cookies
+          {t("hero.cookieHint")}
         </button>
       </motion.div>
 
@@ -137,7 +143,7 @@ export function HeroSection() {
                   'Geist Mono, ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
               }}
             >
-              download stuff effortlessly{" "}
+              {t("hero.tagline")}{" "}
               <span className="text-cyan-500">(&gt;ᴗ•)</span>
             </motion.p>
           </motion.div>
@@ -179,19 +185,16 @@ export function HeroSection() {
               'Geist Mono, ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
           }}
         >
+          <span className="block">{t("hero.footerFree")}</span>
           <span className="block">
-            cliply is free and open source. just one guy tries to keep it
-            running.
-          </span>
-          <span className="block">
-            if it&apos;s useful,{" "}
+            {t("hero.footerUseful")}{" "}
             <a
               href="https://buymeacoffee.com/itssdevk"
               target="_blank"
               rel="noopener noreferrer"
               className="text-slate-500 underline underline-offset-4 transition-colors duration-200 hover:text-cyan-500 dark:text-slate-400 dark:hover:text-cyan-400"
             >
-              buy me a coffee
+              {t("hero.donate")}
             </a>
           </span>
         </p>

--- a/src/main/renderer/src/components/hero/URLInput.tsx
+++ b/src/main/renderer/src/components/hero/URLInput.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react"
 import type { UseFormReturn } from "react-hook-form"
 
 import { useDownloadPath } from "@/lib/hooks/useDownloadPath"
+import { useT, type Key } from "@/lib/i18n"
 import {
   PLATFORM_LIST,
   PLATFORM_REGISTRY
@@ -22,6 +23,7 @@ interface URLInputProps {
 
 export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputProps) {
   const { register, formState: { errors }, watch } = form
+  const t = useT()
   const { selectFolder, isLoading: folderLoading } = useDownloadPath()
   const { selectedPlatform, setSelectedPlatform, setShowMediaDetails } = useAppStore()
   const [isOpen, setIsOpen] = useState(false)
@@ -74,7 +76,7 @@ export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputP
           <input
             {...register("url")}
             type="text"
-            placeholder={config.placeholder}
+            placeholder={t(config.placeholder)}
             disabled={isLoading}
             onFocus={() => onFocusChange(true)}
             onBlur={() => onFocusChange(false)}
@@ -95,7 +97,7 @@ export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputP
             type="button"
             onClick={selectFolder}
             disabled={folderLoading || isLoading}
-            title="Select folder"
+            title={t("url.selectFolder")}
             className={cn(
               "w-7 h-7 rounded-lg border transition-all duration-200 ease-out",
               "flex items-center justify-center flex-shrink-0 bg-transparent",
@@ -129,7 +131,7 @@ export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputP
               <div
                 data-testid="platform-picker-trigger"
                 aria-disabled={isLoading}
-                title={isLoading ? "Wait for the current link to finish" : undefined}
+                title={isLoading ? t("url.pickerBusy") : undefined}
                 className="flex items-center gap-2 px-2.5 py-1.5"
               >
                 <img
@@ -222,7 +224,9 @@ export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputP
           className="px-4"
         >
           <p className="text-sm text-red-600 dark:text-red-400 font-medium" style={{ fontFamily: MONO }}>
-            {errors.url?.message}
+            {/* the form carries a translation key, put there by zod's schema
+                or by the search hook */}
+            {errors.url?.message && t(errors.url.message as Key)}
           </p>
         </motion.div>
       )}
@@ -237,7 +241,7 @@ export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputP
               className="text-sm text-slate-700 dark:text-slate-300 text-center tracking-wide"
               style={{ fontFamily: MONO }}
             >
-              {config.loadingText}
+              {t(config.loadingText)}
               <motion.span
                 animate={{ opacity: [0, 1, 0] }}
                 transition={{ duration: 1, repeat: Infinity, ease: "easeInOut" }}
@@ -248,7 +252,7 @@ export function URLInput({ form, onFocusChange, isLoading, platform }: URLInputP
             </motion.p>
           ) : (
             <p className="text-sm text-slate-600 dark:text-slate-500 text-center" style={{ fontFamily: MONO }}>
-              {config.helperText}
+              {t(config.helperText)}
             </p>
           )}
         </div>

--- a/src/main/renderer/src/components/pinterest/PinterestLayout.tsx
+++ b/src/main/renderer/src/components/pinterest/PinterestLayout.tsx
@@ -1,5 +1,6 @@
 import { ModeToggle } from "@/components/ui/mode-toggle"
 import { FeedbackCard, UnifiedDownloadCard } from "@/components/video"
+import { useT } from "@/lib/i18n"
 import { usePinterestStore } from "@/lib/pinterestStore"
 import { useAppStore } from "@/lib/store"
 import { motion } from "framer-motion"
@@ -10,6 +11,7 @@ import { PinterestThumbnail } from "./PinterestThumbnail"
 export function PinterestLayout() {
   const { pinInfo, url } = usePinterestStore()
   const { setShowMediaDetails } = useAppStore()
+  const t = useT()
 
   if (!pinInfo) return null
 
@@ -97,7 +99,7 @@ export function PinterestLayout() {
               className="flex-shrink-0 px-1 mb-3"
             >
               <div className="text-xs text-slate-500 dark:text-slate-400 font-space-grotesk">
-                Downloads stored at{" "}
+                {t("layout.downloadsAt")}{" "}
                 <span className="font-mono text-slate-600 dark:text-slate-300">
                   ~/Downloads/Cliply
                 </span>

--- a/src/main/renderer/src/components/pinterest/PinterestThumbnail.tsx
+++ b/src/main/renderer/src/components/pinterest/PinterestThumbnail.tsx
@@ -1,4 +1,5 @@
 import { systemApi } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
 import { ExternalLink } from "lucide-react"
@@ -17,12 +18,14 @@ export function PinterestThumbnail({
   title,
   className
 }: PinterestThumbnailProps) {
+  const t = useT()
+
   const handleOpenPin = async () => {
     try {
       await systemApi.openExternal(pinUrl)
     } catch (error) {
       console.error("Failed to open Pinterest link:", error)
-      toast.error("Could not open Pinterest link")
+      toast.error(t("thumb.openFailed", { name: "Pinterest" }))
     }
   }
 
@@ -50,7 +53,7 @@ export function PinterestThumbnail({
         ) : (
           <div className="absolute inset-0 flex items-center justify-center">
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Thumbnail unavailable
+              {t("thumb.unavailable")}
             </p>
           </div>
         )}
@@ -66,7 +69,7 @@ export function PinterestThumbnail({
           )}
         >
           <ExternalLink className="h-4 w-4" />
-          View on Pinterest
+          {t("thumb.viewOn", { name: "Pinterest" })}
         </button>
       </div>
     </motion.div>

--- a/src/main/renderer/src/components/report/ReportIssueDialog.tsx
+++ b/src/main/renderer/src/components/report/ReportIssueDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { toast } from "sonner"
 import { Bug } from "lucide-react"
 import { systemApi } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import {
   buildIssueBody,
   buildIssueUrl,
@@ -22,6 +23,7 @@ import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 export function ReportIssueDialog() {
+  const t = useT()
   const { context, isOpen, close } = useReportStore()
   const [environment, setEnvironment] = useState<ReportEnvironment | null>(null)
   const [notes, setNotes] = useState("")
@@ -60,16 +62,13 @@ export function ReportIssueDialog() {
 
     const opened = await systemApi.openExternal(url)
     if (opened) {
-      toast.success("Opening GitHub", {
-        description: truncated
-          ? "We trimmed the logs to fit. The full report is on your clipboard."
-          : "Review the pre-filled issue and hit submit."
+      toast.success(t("report.opening"), {
+        description: truncated ? t("report.trimmed") : t("report.reviewIt")
       })
       close()
     } else {
-      toast.error("Couldn't open your browser", {
-        description:
-          "The full report is on your clipboard. Paste it at github.com/Cliply/Cliply/issues/new"
+      toast.error(t("report.browserFailed"), {
+        description: t("report.browserFailedDesc")
       })
     }
   }
@@ -94,25 +93,24 @@ export function ReportIssueDialog() {
               <Bug className="h-4 w-4" />
             </span>
             <DialogTitle className="text-slate-900 dark:text-white">
-              Report an issue
+              {t("report.title")}
             </DialogTitle>
           </div>
           <DialogDescription className="text-slate-500 dark:text-slate-400">
-            This opens a pre-filled draft issue on GitHub in your browser. Look
-            it over there, then publish it when you're ready.
+            {t("report.description")}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3">
           <div className={cardClass}>
-            <p className={labelClass}>What went wrong</p>
+            <p className={labelClass}>{t("report.whatWentWrong")}</p>
             <p className="mt-1 text-sm text-slate-700 dark:text-slate-200">
               {context.shortMessage}
             </p>
           </div>
 
           <div className={cardClass}>
-            <p className={labelClass}>Your setup, attached as-is</p>
+            <p className={labelClass}>{t("report.yourSetup")}</p>
             <dl className="mt-1.5 space-y-1">
               {setupFields.map((field) => (
                 <div
@@ -133,9 +131,9 @@ export function ReportIssueDialog() {
           {logTail && (
             <details className={cn(cardClass, "group")}>
               <summary className="flex cursor-pointer items-center justify-between text-sm text-slate-600 select-none dark:text-slate-300">
-                <span>Technical details we&apos;ll attach</span>
+                <span>{t("report.technicalDetails")}</span>
                 <span className="text-xs text-slate-400 group-open:hidden">
-                  show
+                  {t("report.show")}
                 </span>
               </summary>
               <pre className="mt-2 max-h-32 overflow-auto rounded-lg bg-slate-100 p-2 text-xs whitespace-pre-wrap text-slate-500 dark:bg-slate-900/60 dark:text-slate-400">
@@ -149,14 +147,14 @@ export function ReportIssueDialog() {
               htmlFor="report-notes"
               className="text-sm font-medium text-slate-700 dark:text-slate-200"
             >
-              Anything you were doing when it broke?
+              {t("report.notes")}
             </label>
             <textarea
               id="report-notes"
               value={notes}
               onChange={(e) => setNotes(e.target.value)}
               rows={3}
-              placeholder="Optional, but it helps us track it down faster."
+              placeholder={t("report.notesPlaceholder")}
               className="w-full resize-none rounded-xl border border-slate-300 bg-white/70 p-3 text-sm text-slate-800 outline-none transition-colors placeholder:text-slate-400 focus:border-cyan-500 focus:ring-2 focus:ring-cyan-500/20 dark:border-slate-700 dark:bg-slate-800/40 dark:text-slate-100"
             />
           </div>
@@ -169,7 +167,7 @@ export function ReportIssueDialog() {
                 onChange={(e) => setIncludeVideoUrl(e.target.checked)}
                 className="h-4 w-4 rounded border-slate-300 accent-cyan-600 dark:border-slate-600"
               />
-              Include the link I was downloading
+              {t("report.includeLink")}
             </label>
           )}
         </div>
@@ -180,13 +178,13 @@ export function ReportIssueDialog() {
             onClick={close}
             className="text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white"
           >
-            Not now
+            {t("report.notNow")}
           </Button>
           <Button
             onClick={handleSubmit}
             className="bg-cyan-600 text-white hover:bg-cyan-700"
           >
-            Open on GitHub
+            {t("report.openOnGithub")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/main/renderer/src/components/support/SupportDialog.test.tsx
+++ b/src/main/renderer/src/components/support/SupportDialog.test.tsx
@@ -7,6 +7,8 @@
 import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
+import { useLocale } from "@/lib/i18n"
+
 const openExternal = vi.fn(async () => true)
 vi.mock("@/lib/api", () => ({
   systemApi: { openExternal: (...a: unknown[]) => openExternal(...(a as [])) }
@@ -32,7 +34,10 @@ beforeEach(() => {
   }
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  useLocale.setState({ locale: "en" })
+})
 
 async function mount() {
   const { SupportDialog } = await import("./SupportDialog")
@@ -96,6 +101,17 @@ describe("SupportDialog", () => {
       )
     )
     await waitFor(() => expect(screen.queryByText("no thanks")).toBeNull())
+  })
+
+  // an ask nobody can read is worse than no ask: declining has to stay the
+  // plain word it is in english, and russian picks its plural for the count
+  test("declining is a real button in russian too", async () => {
+    useLocale.setState({ locale: "ru" })
+    await mount()
+    listener?.({ count: 5 })
+
+    await waitFor(() => expect(screen.getByText("нет, спасибо")).toBeTruthy())
+    expect(screen.getByText("это уже 5 загрузок")).toBeTruthy()
   })
 
   // a build whose preload predates the support bridge must still render the app

--- a/src/main/renderer/src/components/support/SupportDialog.tsx
+++ b/src/main/renderer/src/components/support/SupportDialog.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 import { Coffee } from "lucide-react"
 import { systemApi } from "@/lib/api"
 import { track } from "@/lib/analytics"
+import { useT } from "@/lib/i18n"
 import {
   Dialog,
   DialogContent,
@@ -31,6 +32,7 @@ const BUY_ME_A_COFFEE = "https://buymeacoffee.com/itssdevk"
  * ends is one where no can be taken for an answer.
  */
 export function SupportDialog() {
+  const t = useT()
   const [count, setCount] = useState<number | null>(null)
 
   useEffect(() => {
@@ -56,13 +58,11 @@ export function SupportDialog() {
               <Coffee className="h-4 w-4" />
             </span>
             <DialogTitle className="text-base font-medium text-slate-900 dark:text-white">
-              that&apos;s {count} downloads
+              {t("support.title", { n: count ?? 0 })}
             </DialogTitle>
           </div>
           <DialogDescription className="text-xs leading-relaxed text-slate-500 dark:text-slate-400">
-            cliply is free, has no ads, and doesn&apos;t track you. it&apos;s
-            built and kept working by one person in their spare time, mostly
-            against youtube changing things on purpose.
+            {t("support.description")}
           </DialogDescription>
         </DialogHeader>
 
@@ -71,7 +71,7 @@ export function SupportDialog() {
             explains itself sounds like it expects to be turned down. one line
             and two buttons says the same thing by not going on about it */}
         <p className="text-xs leading-relaxed text-slate-600 dark:text-slate-300">
-          if it saved you some time, a coffee helps.
+          {t("support.ask")}
         </p>
 
         <div className="flex items-center gap-2">
@@ -85,14 +85,15 @@ export function SupportDialog() {
               close()
             }}
           >
-            buy me a coffee
+            {/* the same ask the hero footer makes, in the same words */}
+            {t("hero.donate")}
           </Button>
           <Button
             variant="ghost"
             className="text-xs text-slate-500 dark:text-slate-400"
             onClick={close}
           >
-            no thanks
+            {t("support.decline")}
           </Button>
         </div>
       </DialogContent>

--- a/src/main/renderer/src/components/tiktok/TikTokLayout.tsx
+++ b/src/main/renderer/src/components/tiktok/TikTokLayout.tsx
@@ -1,5 +1,6 @@
 import { ModeToggle } from "@/components/ui/mode-toggle"
 import { FeedbackCard, UnifiedDownloadCard } from "@/components/video"
+import { useT } from "@/lib/i18n"
 import { useTikTokStore } from "@/lib/tiktokStore"
 import { useAppStore } from "@/lib/store"
 import { motion } from "framer-motion"
@@ -10,6 +11,7 @@ import { TikTokThumbnail } from "./TikTokThumbnail"
 export function TikTokLayout() {
   const { videoInfo, url } = useTikTokStore()
   const { setShowMediaDetails } = useAppStore()
+  const t = useT()
 
   if (!videoInfo) return null
 
@@ -97,7 +99,7 @@ export function TikTokLayout() {
               className="flex-shrink-0 px-1 mb-3"
             >
               <div className="text-xs text-slate-500 dark:text-slate-400 font-space-grotesk">
-                Downloads stored at{" "}
+                {t("layout.downloadsAt")}{" "}
                 <span className="font-mono text-slate-600 dark:text-slate-300">
                   ~/Downloads/Cliply
                 </span>

--- a/src/main/renderer/src/components/tiktok/TikTokThumbnail.tsx
+++ b/src/main/renderer/src/components/tiktok/TikTokThumbnail.tsx
@@ -1,4 +1,5 @@
 import { systemApi } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
 import { ExternalLink } from "lucide-react"
@@ -17,12 +18,14 @@ export function TikTokThumbnail({
   title,
   className
 }: TikTokThumbnailProps) {
+  const t = useT()
+
   const handleOpenVideo = async () => {
     try {
       await systemApi.openExternal(videoUrl)
     } catch (error) {
       console.error("Failed to open TikTok link:", error)
-      toast.error("Could not open TikTok link")
+      toast.error(t("thumb.openFailed", { name: "TikTok" }))
     }
   }
 
@@ -50,7 +53,7 @@ export function TikTokThumbnail({
         ) : (
           <div className="absolute inset-0 flex items-center justify-center">
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Thumbnail unavailable
+              {t("thumb.unavailable")}
             </p>
           </div>
         )}
@@ -66,7 +69,7 @@ export function TikTokThumbnail({
           )}
         >
           <ExternalLink className="h-4 w-4" />
-          View on TikTok
+          {t("thumb.viewOn", { name: "TikTok" })}
         </button>
       </div>
     </motion.div>

--- a/src/main/renderer/src/components/ui/locale-toggle.tsx
+++ b/src/main/renderer/src/components/ui/locale-toggle.tsx
@@ -1,0 +1,60 @@
+import { motion } from "framer-motion"
+
+import { useLocale, type Locale } from "@/lib/i18n"
+import { cn } from "@/lib/utils"
+
+const MONO =
+  'Geist Mono, ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace'
+
+/**
+ * two words rather than a flag or a globe: `en` and `ru` are the same two
+ * letters in either language, so the control needs no label of its own and
+ * nothing about it has to be translated.
+ *
+ * it wears the same chrome as ModeToggle because the two sit side by side.
+ */
+export function LocaleToggle() {
+  const { locale, setLocale } = useLocale()
+
+  const label = (code: Locale) => (
+    <button
+      type="button"
+      onClick={() => setLocale(code)}
+      aria-pressed={locale === code}
+      className={cn(
+        "text-sm transition-colors duration-200",
+        // the colour alone says which locale is on, not which one the keyboard
+        // is about to press, so the ring is the only focus signal there is.
+        // rounded so it traces the label rather than boxing it
+        "rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-slate-400/50 focus-visible:ring-offset-0",
+        locale === code
+          ? "text-slate-700 dark:text-slate-300"
+          : "text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-400"
+      )}
+    >
+      {code}
+    </button>
+  )
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.2 }}
+      className={cn(
+        "h-11 px-3.5 rounded-xl flex items-center gap-2 border",
+        // Dark mode styles
+        "dark:bg-slate-800/60 dark:border-slate-700/50",
+        // Light mode styles
+        "bg-white/80 border-slate-300/50",
+        // Common styles
+        "backdrop-blur-sm shadow-lg"
+      )}
+      style={{ fontFamily: MONO }}
+    >
+      {label("en")}
+      <span className="text-sm text-slate-300 dark:text-slate-600">·</span>
+      {label("ru")}
+    </motion.div>
+  )
+}

--- a/src/main/renderer/src/components/ui/mode-toggle.tsx
+++ b/src/main/renderer/src/components/ui/mode-toggle.tsx
@@ -6,9 +6,11 @@ import { useTheme } from "next-themes"
 import * as React from "react"
 
 import { Button } from "@/components/ui/button"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 
 export function ModeToggle() {
+  const t = useT()
   // resolvedTheme rather than theme: they are the same now that system is off,
   // but an install carrying a stored "system" from an older build would still
   // make theme === "dark" false while rendering dark, and the icon would lie
@@ -61,7 +63,7 @@ export function ModeToggle() {
             <Moon className="h-5 w-5 text-slate-700 dark:text-slate-300" />
           )}
         </motion.div>
-        <span className="sr-only">Toggle theme</span>
+        <span className="sr-only">{t("theme.toggle")}</span>
       </Button>
     </motion.div>
   )

--- a/src/main/renderer/src/components/ui/progress-bar.tsx
+++ b/src/main/renderer/src/components/ui/progress-bar.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useId, type ReactNode } from "react"
 
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 
 /**
@@ -138,6 +139,7 @@ export function ProgressBarTrack({
 }: React.ComponentProps<"div">) {
   const { value, isIndeterminate, valueText, labelId } =
     useProgressBar("ProgressBarTrack")
+  const t = useT()
 
   return (
     <div
@@ -147,7 +149,7 @@ export function ProgressBarTrack({
       aria-valuemax={100}
       // an indeterminate bar must not report a position
       aria-valuenow={isIndeterminate ? undefined : Math.round(value)}
-      aria-valuetext={isIndeterminate ? "Working" : valueText}
+      aria-valuetext={isIndeterminate ? t("progress.working") : valueText}
       data-slot="progress-bar-track"
       className={cn(
         "relative h-1.5 w-full overflow-hidden rounded-full",

--- a/src/main/renderer/src/components/ui/update-notification.tsx
+++ b/src/main/renderer/src/components/ui/update-notification.tsx
@@ -1,4 +1,5 @@
 import { updaterApi, type UpdateInfo, type UpdateProgress } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
 import React, { useEffect, useState } from "react"
@@ -32,6 +33,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
   onUpdateDownloaded,
   showInlineCard = false
 }) => {
+  const t = useT()
   const [updateInfo, setUpdateInfo] = useState<UpdateInfo | null>(null)
   const [downloadProgress, setDownloadProgress] =
     useState<UpdateProgress | null>(null)
@@ -55,10 +57,10 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
       if (info.requiresManualDownload) {
         // macOS: Show manual download dialog
         setShowUpdateDialog(true)
-        toast.success("Update Available", {
-          description: `Version ${info.version} requires manual download on Mac`,
+        toast.success(t("update.available"), {
+          description: t("update.macManual", { version: info.version }),
           action: {
-            label: "Download",
+            label: t("update.download"),
             onClick: () =>
               window.open(
                 `https://github.com/Cliply/Cliply/releases/latest`,
@@ -69,17 +71,17 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
         })
       } else if (info.autoDownloading) {
         // Auto-downloading - only show toast, no dialog
-        toast.success("Update Downloading", {
-          description: `Version ${info.version} is downloading automatically in the background`,
+        toast.success(t("update.downloadingTitle"), {
+          description: t("update.autoDownloading", { version: info.version }),
           duration: 5000
         })
       } else {
         // Manual download - show dialog and toast
         setShowUpdateDialog(true)
-        toast.success("Update Available", {
-          description: `Version ${info.version} is ready to download`,
+        toast.success(t("update.available"), {
+          description: t("update.readyToDownload", { version: info.version }),
           action: {
-            label: "Download",
+            label: t("update.download"),
             onClick: () => handleDownloadUpdate()
           },
           duration: 10000
@@ -95,8 +97,8 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
       () => {
         console.log("App is up to date")
         toast.dismiss("update-check") // Dismiss the checking toast
-        toast.success("App is up to date", {
-          description: "You're running the latest version",
+        toast.success(t("update.upToDate"), {
+          description: t("update.upToDateDesc"),
           duration: 3000
         })
       }
@@ -113,12 +115,12 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
         // Show progress toast every 10% or if it's the first progress update
         if (progress.percent % 10 === 0 || progress.percent < 5) {
           toast.loading(
-            `Downloading Update: ${Math.round(progress.percent)}%`,
+            t("update.progress", { percent: Math.round(progress.percent) }),
             {
               id: "update-progress",
               description: progress.bytesPerSecond
                 ? `${Math.round(progress.bytesPerSecond / 1024)} KB/s`
-                : "Downloading in background..."
+                : t("update.inBackground")
             }
           )
         }
@@ -140,10 +142,10 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
         // All updates now use simple auto-install on quit
         setShowInstallDialog(true)
 
-        toast.success("Update Ready to Install!", {
-          description: `Version ${info.version} has been downloaded successfully. It will install when you close the app.`,
+        toast.success(t("update.readyToInstallToast"), {
+          description: t("update.downloadedDesc", { version: info.version }),
           action: {
-            label: "Install Now",
+            label: t("update.installNow"),
             onClick: () => handleInstallUpdate()
           },
           duration: 0 // Keep open until dismissed
@@ -157,7 +159,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
     // Update checking
     const unsubscribeChecking = updaterApi.events.onUpdateChecking(() => {
       console.log("Checking for updates...")
-      toast.loading("Checking for updates...", {
+      toast.loading(t("update.checking"), {
         id: "update-check"
       })
     })
@@ -170,7 +172,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
       setIsDownloading(false)
 
       toast.dismiss("update-check")
-      toast.error("Update Error", {
+      toast.error(t("update.error"), {
         description: error.message,
         duration: 5000
       })
@@ -187,31 +189,28 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
       setShowUpdateDialog(false)
       setError(null)
 
-      toast.loading("Preparing download...", {
+      toast.loading(t("update.preparing"), {
         id: "update-download",
-        description: "Initializing update download"
+        description: t("update.preparingDesc")
       })
 
       await updaterApi.downloadUpdate()
 
       toast.dismiss("update-download")
-      toast.success("Download Started", {
-        description:
-          "Update is downloading in the background. You can continue using the app.",
+      toast.success(t("update.started"), {
+        description: t("update.startedDesc"),
         duration: 4000
       })
     } catch (error) {
       console.error("Failed to download update:", error)
       setError(
-        error instanceof Error ? error.message : "Failed to download update"
+        error instanceof Error ? error.message : t("update.downloadFailedDesc")
       )
 
       toast.dismiss("update-download")
-      toast.error("Download Failed", {
+      toast.error(t("update.downloadFailed"), {
         description:
-          error instanceof Error
-            ? error.message
-            : "Please try again or check your internet connection"
+          error instanceof Error ? error.message : t("update.checkConnection")
       })
     }
   }
@@ -220,19 +219,19 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
     try {
       setShowInstallDialog(false)
 
-      toast.loading("Installing Update", {
-        description: "The app will close and reopen with the new version",
+      toast.loading(t("update.installing"), {
+        description: t("update.installingDesc"),
         duration: 0
       })
 
       await updaterApi.installUpdate()
     } catch (error) {
       console.error("Failed to install update:", error)
-      toast.error("Installation Failed", {
+      toast.error(t("update.installFailed"), {
         description:
           error instanceof Error
             ? error.message
-            : "Please try downloading the update again",
+            : t("update.installFailedDesc"),
         duration: 6000
       })
     }
@@ -243,16 +242,19 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
       await updaterApi.checkForUpdates()
     } catch (error) {
       console.error("Failed to check for updates:", error)
-      toast.error("Check Failed", {
+      // the same failure the hero's own check reports, in the same words
+      toast.error(t("hero.updateCheckFailed"), {
         description:
-          error instanceof Error ? error.message : "Failed to check for updates"
+          error instanceof Error
+            ? error.message
+            : t("hero.updateCheckFailedBody")
       })
     }
   }
 
   const handleForceSecurityCheck = async () => {
     try {
-      toast.loading("Checking for updates...", {
+      toast.loading(t("update.checking"), {
         id: "update-check"
       })
 
@@ -264,9 +266,11 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
     } catch (error) {
       console.error("Failed to check for updates:", error)
       toast.dismiss("update-check")
-      toast.error("Check Failed", {
+      toast.error(t("hero.updateCheckFailed"), {
         description:
-          error instanceof Error ? error.message : "Failed to check for updates"
+          error instanceof Error
+            ? error.message
+            : t("hero.updateCheckFailedBody")
       })
     }
   }
@@ -299,11 +303,13 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 </div>
                 <div>
                   <div className="font-medium text-slate-900 dark:text-white">
-                    Downloading Update
+                    {t("update.cardDownloading")}
                   </div>
                   <CardDescription className="text-xs text-slate-600 dark:text-slate-400">
-                    Version {updateInfo?.version} • {downloadProgress.percent}%
-                    complete
+                    {t("update.cardProgress", {
+                      version: updateInfo?.version ?? "",
+                      percent: downloadProgress.percent
+                    })}
                   </CardDescription>
                 </div>
               </CardTitle>
@@ -345,10 +351,12 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 </div>
                 <div>
                   <div className="font-medium text-slate-900 dark:text-white">
-                    Update Ready
+                    {t("update.cardReady")}
                   </div>
                   <CardDescription className="text-xs text-slate-600 dark:text-slate-400">
-                    Version {updateInfo?.version} is ready to install
+                    {t("update.cardReadyDesc", {
+                      version: updateInfo?.version ?? ""
+                    })}
                   </CardDescription>
                 </div>
               </CardTitle>
@@ -359,7 +367,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 size="sm"
                 className="w-full bg-cyan-600 hover:bg-cyan-700 text-white border-2 border-cyan-600 hover:border-cyan-700 transition-all duration-200"
               >
-                Install & Restart
+                {t("update.installRestart")}
               </Button>
             </CardContent>
           </Card>
@@ -391,7 +399,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 </div>
                 <div>
                   <div className="font-medium text-slate-900 dark:text-white">
-                    Update Error
+                    {t("update.error")}
                   </div>
                   <CardDescription className="text-xs text-slate-600 dark:text-slate-400">
                     {error}
@@ -406,7 +414,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 variant="outline"
                 className="w-full"
               >
-                Try Again
+                {t("update.tryAgain")}
               </Button>
               <Button
                 onClick={handleForceSecurityCheck}
@@ -414,7 +422,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 variant="outline"
                 className="w-full"
               >
-                Check for Important Updates
+                {t("update.importantUpdates")}
               </Button>
             </CardContent>
           </Card>
@@ -448,12 +456,12 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 </div>
                 <div>
                   <DialogTitle className="text-left">
-                    Update Available
+                    {t("update.available")}
                   </DialogTitle>
                   <DialogDescription className="text-left">
                     {updateInfo?.requiresManualDownload
-                      ? "We can't auto-update on Mac. Click 'Learn Why' to find out more."
-                      : "A new version of Cliply is available."}
+                      ? t("update.macDesc")
+                      : t("update.newVersion")}
                   </DialogDescription>
                 </div>
               </div>
@@ -463,12 +471,15 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
               <div className="text-center py-6">
                 <div className="rounded-lg bg-slate-100/80 dark:bg-slate-700/50 p-4">
                   <h4 className="font-medium text-slate-900 dark:text-white">
-                    Version {updateInfo.version}
+                    {t("update.version", { version: updateInfo.version })}
                   </h4>
                   {updateInfo.releaseDate && (
                     <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
-                      Released{" "}
-                      {new Date(updateInfo.releaseDate).toLocaleDateString()}
+                      {t("update.released", {
+                        date: new Date(
+                          updateInfo.releaseDate
+                        ).toLocaleDateString()
+                      })}
                     </p>
                   )}
                 </div>
@@ -485,7 +496,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                   onClick={() => setShowUpdateDialog(false)}
                   className="w-full sm:w-auto"
                 >
-                  Later
+                  {t("update.later")}
                 </Button>
                 <Button
                   onClick={() =>
@@ -497,7 +508,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                   variant="outline"
                   className="w-full sm:w-auto"
                 >
-                  Learn Why
+                  {t("update.learnWhy")}
                 </Button>
                 <Button
                   onClick={() =>
@@ -508,7 +519,7 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                   }
                   className="w-full sm:w-auto bg-cyan-600 hover:bg-cyan-700 text-white border-2 border-cyan-600 hover:border-cyan-700 transition-all duration-200"
                 >
-                  Download from GitHub
+                  {t("update.downloadFromGithub")}
                 </Button>
               </>
             ) : (
@@ -519,13 +530,13 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                   onClick={() => setShowUpdateDialog(false)}
                   className="w-full sm:w-auto"
                 >
-                  Later
+                  {t("update.later")}
                 </Button>
                 <Button
                   onClick={handleDownloadUpdate}
                   className="w-full sm:w-auto bg-cyan-600 hover:bg-cyan-700 text-white border-2 border-cyan-600 hover:border-cyan-700 transition-all duration-200"
                 >
-                  Download Update
+                  {t("update.downloadUpdate")}
                 </Button>
               </>
             )}
@@ -552,11 +563,10 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
                 </div>
                 <div>
                   <DialogTitle className="text-left">
-                    Update Ready to Install
+                    {t("update.readyToInstall")}
                   </DialogTitle>
                   <DialogDescription className="text-left">
-                    The update has been downloaded and is ready to install. The
-                    app will restart automatically.
+                    {t("update.readyToInstallDesc")}
                   </DialogDescription>
                 </div>
               </div>
@@ -566,10 +576,10 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
               <div className="text-center py-6">
                 <div className="rounded-lg bg-slate-100/80 dark:bg-slate-700/50 p-4">
                   <h4 className="font-medium text-slate-900 dark:text-white">
-                    Version {updateInfo.version}
+                    {t("update.version", { version: updateInfo.version })}
                   </h4>
                   <p className="text-sm text-slate-600 dark:text-slate-400 mt-1">
-                    Ready to install when you're ready
+                    {t("update.whenReady")}
                   </p>
                 </div>
               </div>
@@ -582,13 +592,13 @@ export const UpdateNotification: React.FC<UpdateNotificationProps> = ({
               onClick={() => setShowInstallDialog(false)}
               className="w-full sm:w-auto"
             >
-              Later
+              {t("update.later")}
             </Button>
             <Button
               onClick={handleInstallUpdate}
               className="w-full sm:w-auto bg-cyan-600 hover:bg-cyan-700 text-white border-2 border-cyan-600 hover:border-cyan-700 transition-all duration-200"
             >
-              Install & Restart
+              {t("update.installRestart")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/main/renderer/src/components/video/AudioDownloadButton.tsx
+++ b/src/main/renderer/src/components/video/AudioDownloadButton.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/tooltip"
 import { formatDuration, languageName, validateTimeRange } from "@/lib/api"
 import { useAudioDownload } from "@/lib/hooks/useAudioDownload"
+import { useT } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { isTerminalReason } from "@/lib/downloadOutcome"
 import { cn } from "@/lib/utils"
@@ -36,6 +37,7 @@ export function AudioDownloadButton({
   } = useYouTubeStore()
 
   const audioDownloadMutation = useAudioDownload()
+  const t = useT()
 
   const selectedDuration = audioTimeRange.end - audioTimeRange.start
 
@@ -108,19 +110,21 @@ export function AudioDownloadButton({
         )}
       >
         <h4 className="font-medium text-slate-900 dark:text-white mb-2">
-          Download Summary
+          {t("card.summary")}
         </h4>
         <div className="space-y-1 text-sm">
           <div className="flex justify-between">
             <span className="text-slate-600 dark:text-slate-400">
-              Duration:
+              {t("card.duration")}
             </span>
             <span className="font-medium text-slate-900 dark:text-white">
               {formatDuration(selectedDuration)}
             </span>
           </div>
           <div className="flex justify-between">
-            <span className="text-slate-600 dark:text-slate-400">Format:</span>
+            <span className="text-slate-600 dark:text-slate-400">
+              {t("card.format")}
+            </span>
             <span className="font-medium text-slate-900 dark:text-white">
               {selectedAudioMode?.toUpperCase()}
             </span>
@@ -129,7 +133,7 @@ export function AudioDownloadButton({
           {selectedAudioLanguage && (
             <div className="flex justify-between">
               <span className="text-slate-600 dark:text-slate-400">
-                Language:
+                {t("card.language")}
               </span>
               <span className="font-medium text-slate-900 dark:text-white">
                 {languageName(selectedAudioLanguage)}
@@ -138,7 +142,7 @@ export function AudioDownloadButton({
           )}
           <div className="flex justify-between">
             <span className="text-slate-600 dark:text-slate-400">
-              Time Range:
+              {t("card.timeRange")}
             </span>
             <span className="font-medium text-slate-900 dark:text-white">
               {Math.floor(audioTimeRange.start / 60)}:
@@ -154,7 +158,7 @@ export function AudioDownloadButton({
               <div className="flex items-center gap-2">
                 <Scissors className="h-4 w-4 text-slate-500 dark:text-slate-500" />
                 <span className="text-sm text-slate-600 dark:text-slate-400">
-                  Precise Cut:
+                  {t("card.preciseCut")}
                 </span>
               </div>
               <Tooltip>
@@ -170,11 +174,11 @@ export function AudioDownloadButton({
                         : "hover:bg-slate-100 dark:hover:bg-slate-700"
                     )}
                   >
-                    {audioPreciseCut ? "Enabled" : "Disabled"}
+                    {audioPreciseCut ? t("card.enabled") : t("card.disabled")}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="left">
-                  <p>Turn off for faster download but less precise cuts</p>
+                  <p>{t("card.preciseCutHint")}</p>
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -195,10 +199,10 @@ export function AudioDownloadButton({
       >
         {audioDownloadMutation.isPending ? (
           <>
-            <span className="animate-pulse">Downloading...</span>
+            <span className="animate-pulse">{t("download.inProgress")}</span>
           </>
         ) : (
-          "Download Audio"
+          t("download.audio")
         )}
       </Button>
 
@@ -206,7 +210,7 @@ export function AudioDownloadButton({
       {audioDownloadMutation.isPending && (
         <DownloadProgressBar
           state={audioDownloadMutation.downloadState}
-          label="audio"
+          label={t("media.audio")}
           onCancel={audioDownloadMutation.cancelDownload}
         />
       )}
@@ -214,7 +218,7 @@ export function AudioDownloadButton({
       {/* Helper Text */}
       {!audioDownloadMutation.isPending && (
         <div className="text-xs text-slate-500 dark:text-slate-500 text-center">
-          Audio will be downloaded with the selected time range and format
+          {t("download.audioHint")}
         </div>
       )}
     </motion.div>

--- a/src/main/renderer/src/components/video/AudioFormatDropdown.tsx
+++ b/src/main/renderer/src/components/video/AudioFormatDropdown.tsx
@@ -1,4 +1,5 @@
 import type { AudioMode } from "@/lib/api"
+import { useT, type Key } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { motion } from "framer-motion"
 import { Headphones } from "lucide-react"
@@ -9,18 +10,21 @@ import { SelectionDropdown } from "./SelectionDropdown"
  *
  * two conversions and the untouched stream - no quality ladder, because the
  * audio yt-dlp starts from is the best one the video has either way
+ *
+ * the rows are built once, at module load, so they carry translation keys
+ * rather than words: the locale can change after that
  */
 const AUDIO_MODES: {
   mode: AudioMode
-  label: string
-  detail: string
+  label: Key
+  detail: Key
 }[] = [
-  { mode: "mp3", label: "MP3", detail: "Converted · plays everywhere" },
-  { mode: "m4a", label: "M4A", detail: "AAC · converted" },
+  { mode: "mp3", label: "format.mp3", detail: "format.mp3Detail" },
+  { mode: "m4a", label: "format.m4a", detail: "format.m4aDetail" },
   {
     mode: "original",
-    label: "Original",
-    detail: "Source quality, no re-encode · usually WEBM/Opus"
+    label: "dropdown.original",
+    detail: "format.originalDetail"
   }
 ]
 
@@ -37,6 +41,7 @@ export function AudioFormatDropdown({
   className
 }: AudioFormatDropdownProps) {
   const { selectedAudioMode, setSelectedAudioMode } = useYouTubeStore()
+  const t = useT()
 
   // no defaulting effect: the three modes are the same on every video, so mp3
   // is simply what the store starts on
@@ -48,14 +53,14 @@ export function AudioFormatDropdown({
   return (
     <SelectionDropdown
       icon={Headphones}
-      heading="Audio Format"
-      placeholder="Select audio format..."
+      heading={t("dropdown.audioFormat")}
+      placeholder={t("dropdown.audioFormatPlaceholder")}
       options={AUDIO_MODES}
       selected={selected}
       onSelect={(option) => setSelectedAudioMode(option.mode)}
       optionKey={(option) => option.mode}
-      renderLabel={(option) => option.label}
-      renderDetail={(option) => option.detail}
+      renderLabel={(option) => t(option.label)}
+      renderDetail={(option) => t(option.detail)}
       className={className}
       footer={
         selected && (
@@ -64,9 +69,9 @@ export function AudioFormatDropdown({
             animate={{ opacity: 1 }}
             className="text-sm text-slate-600 dark:text-slate-400"
           >
-            Selected:{" "}
+            {t("dropdown.selected")}{" "}
             <span className="font-medium text-slate-900 dark:text-white">
-              {selected.label}
+              {t(selected.label)}
             </span>
           </motion.div>
         )

--- a/src/main/renderer/src/components/video/AudioTrackDropdown.tsx
+++ b/src/main/renderer/src/components/video/AudioTrackDropdown.tsx
@@ -1,5 +1,6 @@
 import type { AudioTrack } from "@/lib/api"
 import { languageName } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { Languages } from "lucide-react"
 import { useEffect } from "react"
@@ -23,6 +24,7 @@ export function AudioTrackDropdown({
   className
 }: AudioTrackDropdownProps) {
   const { selectedAudioLanguage, setSelectedAudioLanguage } = useYouTubeStore()
+  const t = useT()
 
   const hasChoice = tracks.length > 1
 
@@ -52,14 +54,16 @@ export function AudioTrackDropdown({
   return (
     <SelectionDropdown
       icon={Languages}
-      heading="Audio Language"
-      placeholder="Select audio language..."
+      heading={t("dropdown.audioLanguage")}
+      placeholder={t("dropdown.audioLanguagePlaceholder")}
       options={tracks}
       selected={selected}
       onSelect={(track) => setSelectedAudioLanguage(track.code)}
       optionKey={(track) => track.code}
       renderLabel={(track) => languageName(track.code)}
-      renderDetail={(track) => (track.is_original ? "Original" : null)}
+      renderDetail={(track) =>
+        track.is_original ? t("dropdown.original") : null
+      }
       className={className}
     />
   )

--- a/src/main/renderer/src/components/video/CompactSearch.test.tsx
+++ b/src/main/renderer/src/components/video/CompactSearch.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+//
+// the second url box, the one on the details screen after a video has loaded.
+//
+// it shares `platform-config` and the zod schemas with the hero's input, and
+// both of those now carry translation keys rather than sentences. this one was
+// missed on the first pass and rendered `url.placeholder` at an english user,
+// which is exactly the failure a shared contract produces: the surface that
+// nobody edited is the one that breaks.
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { en } from "@/lib/i18n/en"
+import { ru } from "@/lib/i18n/ru"
+import { useLocale } from "@/lib/i18n"
+import { CompactSearch } from "./CompactSearch"
+
+vi.mock("@/lib/api", () => ({
+  DownloadError: class extends Error {},
+  videoApi: { getVideoInfo: vi.fn() },
+  pinterestApi: { getInfo: vi.fn() },
+  tiktokApi: { getInfo: vi.fn() }
+}))
+vi.mock("sonner", () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() })
+}))
+
+afterEach(() => {
+  cleanup()
+  useLocale.setState({ locale: "en" })
+})
+
+const submit = (url: string) => {
+  fireEvent.change(screen.getByRole("textbox"), { target: { value: url } })
+  fireEvent.submit(screen.getByRole("textbox"))
+}
+
+describe("the details-screen search box", () => {
+  test("asks for a replacement link in words, not in a key", () => {
+    render(<CompactSearch />)
+
+    expect(
+      screen.getByPlaceholderText(en["url.replacePlaceholder"])
+    ).toBeTruthy()
+  })
+
+  test("rejects a bad link in words, not in a key", async () => {
+    render(<CompactSearch />)
+
+    submit("not a link")
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(en["validation.youtubeInvalid"])
+      ).toBeTruthy()
+    )
+  })
+
+  test("says both in russian when the locale is russian", async () => {
+    useLocale.setState({ locale: "ru" })
+    render(<CompactSearch />)
+
+    expect(
+      screen.getByPlaceholderText(ru["url.replacePlaceholder"])
+    ).toBeTruthy()
+
+    submit("not a link")
+
+    await waitFor(() =>
+      expect(screen.getByText(ru["validation.youtubeInvalid"])).toBeTruthy()
+    )
+  })
+})

--- a/src/main/renderer/src/components/video/CompactSearch.tsx
+++ b/src/main/renderer/src/components/video/CompactSearch.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button"
 import { useMediaSearch } from "@/lib/hooks/useMediaSearch"
+import { useT, type Key } from "@/lib/i18n"
 import type { Platform } from "@/lib/store"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
@@ -22,9 +23,9 @@ export function CompactSearch({
     form,
     isLoading: storeLoading,
     onSubmit,
-    handleClear,
-    config
+    handleClear
   } = useMediaSearch(platform, { onSearch })
+  const t = useT()
 
   const isLoading = externalLoading || storeLoading
 
@@ -42,7 +43,7 @@ export function CompactSearch({
           <input
             {...form.register("url")}
             type="text"
-            placeholder={config.placeholder.replace("paste", "Enter new").replace("here...", "URL...")}
+            placeholder={t("url.replacePlaceholder")}
             disabled={isLoading}
             className={cn(
               "w-full h-12 pl-12 pr-16 rounded-xl border transition-all duration-200",
@@ -89,13 +90,13 @@ export function CompactSearch({
           </div>
         </div>
 
-        {form.formState.errors.url && (
+        {form.formState.errors.url?.message && (
           <motion.p
             initial={{ opacity: 0, y: -5 }}
             animate={{ opacity: 1, y: 0 }}
             className="mt-2 text-sm text-red-600 dark:text-red-400"
           >
-            {form.formState.errors.url.message}
+            {t(form.formState.errors.url.message as Key)}
           </motion.p>
         )}
       </form>

--- a/src/main/renderer/src/components/video/DownloadProgressBar.tsx
+++ b/src/main/renderer/src/components/video/DownloadProgressBar.tsx
@@ -8,6 +8,7 @@ import {
   ProgressBarTrack,
   ProgressBarValue
 } from "@/components/ui/progress-bar"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 
 interface DownloadProgressBarState {
@@ -21,6 +22,7 @@ interface DownloadProgressBarState {
 
 interface DownloadProgressBarProps {
   state: DownloadProgressBarState
+  /** the media noun, already translated - "video", "аудио" */
   label: string
   className?: string
   /** omit to render progress without a stop control */
@@ -40,13 +42,14 @@ export function DownloadProgressBar({
   className,
   onCancel
 }: DownloadProgressBarProps) {
+  const t = useT()
   const isStarting = state.status === "starting"
   const isIndeterminate = state.indeterminate || isStarting
 
   const meta = isIndeterminate
     ? isStarting
-      ? "Starting up"
-      : "Progress isn't reported while trimming"
+      ? t("progress.startingUp")
+      : t("progress.trimming")
     : [state.speed, state.eta && `ETA ${state.eta}`].filter(Boolean).join("  ·  ")
 
   return (
@@ -57,7 +60,9 @@ export function DownloadProgressBar({
     >
       <ProgressBarHeader>
         <ProgressBarLabel>
-          {isIndeterminate ? `Processing ${label}` : `Downloading ${label}`}
+          {isIndeterminate
+            ? t("progress.processing", { label })
+            : t("progress.downloading", { label })}
         </ProgressBarLabel>
         <ProgressBarValue />
       </ProgressBarHeader>
@@ -84,12 +89,14 @@ function StopButton({
   onCancel: () => void
   disabled: boolean
 }) {
+  const t = useT()
+
   return (
     <button
       type="button"
       onClick={onCancel}
       disabled={disabled}
-      title={disabled ? "Starting up" : "Stop this download"}
+      title={disabled ? t("progress.startingUp") : t("progress.stopTitle")}
       className={cn(
         "-my-0.5 flex shrink-0 items-center gap-1 rounded-lg border px-2 py-0.5",
         "font-mono text-[11px] leading-4 transition-colors duration-200 ease-out",
@@ -103,7 +110,7 @@ function StopButton({
       )}
     >
       <X className="h-3 w-3" />
-      Stop
+      {t("progress.stop")}
     </button>
   )
 }

--- a/src/main/renderer/src/components/video/FeedbackCard.tsx
+++ b/src/main/renderer/src/components/video/FeedbackCard.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
 import { Heart, MessageSquare } from "lucide-react"
@@ -8,6 +9,8 @@ interface FeedbackCardProps {
 }
 
 export function FeedbackCard({ className }: FeedbackCardProps) {
+  const t = useT()
+
   const handleFeedback = () => {
     // Open cliply.space/hey page
     window.open("https://cliply.space/hey", "_blank")
@@ -37,10 +40,10 @@ export function FeedbackCard({ className }: FeedbackCardProps) {
           </div>
           <div>
             <h3 className="font-medium text-cyan-900 dark:text-cyan-100">
-              Help us improve
+              {t("feedback.title")}
             </h3>
             <p className="text-sm text-cyan-700 dark:text-cyan-300">
-              Request a feature
+              {t("feedback.subtitle")}
             </p>
           </div>
         </div>
@@ -54,7 +57,7 @@ export function FeedbackCard({ className }: FeedbackCardProps) {
           )}
         >
           <MessageSquare className="h-4 w-4 mr-01" />
-          tap me :)
+          {t("feedback.cta")}
         </Button>
       </div>
     </motion.div>

--- a/src/main/renderer/src/components/video/TimeRangeSelector.tsx
+++ b/src/main/renderer/src/components/video/TimeRangeSelector.tsx
@@ -4,6 +4,7 @@ import {
   timeToSeconds,
   validateTimeRange
 } from "@/lib/api"
+import { useT, type Key } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
@@ -20,9 +21,10 @@ export function TimeRangeSelector({
   className
 }: TimeRangeSelectorProps) {
   const { audioTimeRange, setAudioTimeRange } = useYouTubeStore()
+  const t = useT()
   const [startTimeInput, setStartTimeInput] = useState("00:00")
   const [endTimeInput, setEndTimeInput] = useState(secondsToTime(maxDuration))
-  const [validationError, setValidationError] = useState<string | null>(null)
+  const [validationError, setValidationError] = useState<Key | null>(null)
 
   // Initialize end time when component mounts
   useEffect(() => {
@@ -41,7 +43,7 @@ export function TimeRangeSelector({
       setValidationError(null)
       return true
     } else {
-      setValidationError(validation.error || "Invalid time range")
+      setValidationError(validation.error ?? "time.invalid")
       return false
     }
   }
@@ -73,7 +75,7 @@ export function TimeRangeSelector({
       <div className="flex items-center gap-2">
         <Clock className="h-5 w-5 text-slate-600 dark:text-slate-400" />
         <h3 className="font-medium text-slate-900 dark:text-white">
-          Time Range Selection
+          {t("time.selection")}
         </h3>
       </div>
 
@@ -82,7 +84,7 @@ export function TimeRangeSelector({
         {/* Start Time */}
         <div className="space-y-2">
           <label className="text-sm font-medium text-slate-600 dark:text-slate-400">
-            Start Time
+            {t("time.start")}
           </label>
           <input
             type="text"
@@ -108,7 +110,7 @@ export function TimeRangeSelector({
         {/* End Time */}
         <div className="space-y-2">
           <label className="text-sm font-medium text-slate-600 dark:text-slate-400">
-            End Time
+            {t("time.end")}
           </label>
           <input
             type="text"
@@ -139,7 +141,7 @@ export function TimeRangeSelector({
           animate={{ opacity: 1, y: 0 }}
           className="text-sm text-red-600 dark:text-red-400"
         >
-          {validationError}
+          {t(validationError)}
         </motion.div>
       )}
 
@@ -150,7 +152,7 @@ export function TimeRangeSelector({
           animate={{ opacity: 1 }}
           className="text-sm text-slate-600 dark:text-slate-400"
         >
-          Selected duration:{" "}
+          {t("time.selectedDuration")}{" "}
           <span className="font-medium text-slate-900 dark:text-white">
             {formatDuration(selectedDuration)}
           </span>
@@ -159,7 +161,7 @@ export function TimeRangeSelector({
 
       {/* Helper Text */}
       <div className="text-xs text-slate-500 dark:text-slate-500">
-        Use MM:SS or HH:MM:SS format. Max duration: {secondsToTime(maxDuration)}
+        {t("time.helper", { max: secondsToTime(maxDuration) })}
       </div>
     </motion.div>
   )

--- a/src/main/renderer/src/components/video/UnifiedDownloadCard.tsx
+++ b/src/main/renderer/src/components/video/UnifiedDownloadCard.tsx
@@ -12,6 +12,7 @@ import {
   type QualityTier,
   type TikTokVideoInfoResponse
 } from "@/lib/api"
+import { localizeError, useT } from "@/lib/i18n"
 import { reportActions } from "@/lib/reportStore"
 import { usePinterestStore } from "@/lib/pinterestStore"
 import { useTikTokStore } from "@/lib/tiktokStore"
@@ -88,6 +89,7 @@ function YouTubeDownloadCard({
 }) {
   const { audioTimeRange, selectedAudioMode, videoTimeRange, selectedTier } =
     useYouTubeStore()
+  const t = useT()
 
   const [isVideoQualityDropdownOpen, setIsVideoQualityDropdownOpen] =
     useState(false)
@@ -135,13 +137,13 @@ function YouTubeDownloadCard({
               value="video"
               className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:shadow-sm dark:data-[state=active]:bg-slate-700 dark:data-[state=active]:border-slate-600 transition-all duration-200"
             >
-              🎬 Video Download
+              🎬 {t("card.tabVideo")}
             </TabsTrigger>
             <TabsTrigger
               value="audio"
               className="flex items-center gap-2 data-[state=active]:bg-white data-[state=active]:shadow-sm dark:data-[state=active]:bg-slate-700 dark:data-[state=active]:border-slate-600 transition-all duration-200"
             >
-              🎵 Audio Only
+              🎵 {t("card.tabAudio")}
             </TabsTrigger>
           </TabsList>
         </div>
@@ -150,7 +152,7 @@ function YouTubeDownloadCard({
           <div className="space-y-4">
             <div className="mb-6">
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Download video with automatically paired audio
+                {t("card.videoIntro")}
               </p>
             </div>
 
@@ -182,7 +184,7 @@ function YouTubeDownloadCard({
           <div className="space-y-4">
             <div className="mb-6">
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Extract audio from the video with custom time range
+                {t("card.audioIntro")}
               </p>
             </div>
 
@@ -222,6 +224,8 @@ function SimpleVideoDownloadCard({
   onDownload: () => void
   className?: string
 }) {
+  const t = useT()
+
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -238,7 +242,7 @@ function SimpleVideoDownloadCard({
       <div className="p-6 space-y-4">
         <div className="space-y-1">
           <h3 className="text-base font-medium text-slate-900 dark:text-white">
-            Download Video
+            {t("download.video")}
           </h3>
           <p className="text-sm text-slate-600 dark:text-slate-400">
             {subtitle}
@@ -249,8 +253,12 @@ function SimpleVideoDownloadCard({
           <p className="font-medium text-slate-900 dark:text-white line-clamp-2">
             {videoInfo.title}
           </p>
-          <p className="mt-1">Uploader: {videoInfo.uploader}</p>
-          <p>Duration: {videoInfo.duration_string}</p>
+          <p className="mt-1">
+            {t("card.uploader")} {videoInfo.uploader}
+          </p>
+          <p>
+            {t("card.duration")} {videoInfo.duration_string}
+          </p>
         </div>
 
         <Button
@@ -262,7 +270,7 @@ function SimpleVideoDownloadCard({
             "disabled:opacity-50 disabled:cursor-not-allowed shadow-lg hover:shadow-xl"
           )}
         >
-          {isDownloading ? "Downloading..." : "Download Video"}
+          {isDownloading ? t("download.inProgress") : t("download.video")}
         </Button>
       </div>
     </motion.div>
@@ -277,6 +285,7 @@ function PinterestDownloadCard({
   className?: string
 }) {
   const { url, isDownloading, setIsDownloading } = usePinterestStore()
+  const t = useT()
 
   const handleDownload = async () => {
     if (!url || isDownloading) return
@@ -294,7 +303,7 @@ function PinterestDownloadCard({
       })
 
       await pinterestApi.download({ url, title: pinInfo?.title })
-      toast.success("Download complete!", { action: { label: "Open Folder", onClick: () => systemApi.openDownloadFolder() } })
+      toast.success(t("download.complete"), { action: { label: t("toast.openFolder"), onClick: () => systemApi.openDownloadFolder() } })
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to download video"
       if (message.includes("network") || message.includes("fetch")) { showServerOverwhelmedToast() }
@@ -308,8 +317,12 @@ function PinterestDownloadCard({
           videoUrl: url
         })
         showDownloadErrorToast(
-          "Download failed",
-          message,
+          t("download.failed"),
+          // the staged report above keeps main's english; the toast is read
+          localizeError({
+            message,
+            category: error instanceof DownloadError ? error.category : undefined
+          }).message,
           error instanceof DownloadError ? error.category : undefined,
           "pinterest"
         )
@@ -322,7 +335,7 @@ function PinterestDownloadCard({
   return (
     <SimpleVideoDownloadCard
       videoInfo={pinInfo}
-      subtitle="Best available quality, saved as MP4."
+      subtitle={t("card.pinterestSubtitle")}
       isDownloading={isDownloading}
       onDownload={handleDownload}
       className={className}
@@ -338,6 +351,7 @@ function TikTokDownloadCard({
   className?: string
 }) {
   const { url, isDownloading, setIsDownloading } = useTikTokStore()
+  const t = useT()
 
   const handleDownload = async () => {
     if (!url || isDownloading) return
@@ -353,7 +367,7 @@ function TikTokDownloadCard({
       })
 
       await tiktokApi.download({ url, title: tikTokInfo?.title })
-      toast.success("Download complete!", { action: { label: "Open Folder", onClick: () => systemApi.openDownloadFolder() } })
+      toast.success(t("download.complete"), { action: { label: t("toast.openFolder"), onClick: () => systemApi.openDownloadFolder() } })
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to download video"
       if (message.includes("network") || message.includes("fetch")) { showServerOverwhelmedToast() }
@@ -367,8 +381,12 @@ function TikTokDownloadCard({
           videoUrl: url
         })
         showDownloadErrorToast(
-          "Download failed",
-          message,
+          t("download.failed"),
+          // the staged report above keeps main's english; the toast is read
+          localizeError({
+            message,
+            category: error instanceof DownloadError ? error.category : undefined
+          }).message,
           error instanceof DownloadError ? error.category : undefined,
           "tiktok"
         )
@@ -381,7 +399,7 @@ function TikTokDownloadCard({
   return (
     <SimpleVideoDownloadCard
       videoInfo={tikTokInfo}
-      subtitle="Best available quality, saved as MP4. No watermark."
+      subtitle={t("card.tiktokSubtitle")}
       isDownloading={isDownloading}
       onDownload={handleDownload}
       className={className}

--- a/src/main/renderer/src/components/video/VideoDownloadButton.test.tsx
+++ b/src/main/renderer/src/components/video/VideoDownloadButton.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+//
+// the download button under a russian locale. the card around it is the app's
+// tightest layout, so this is the one label that must never fall back to
+// english: it is the button the whole screen exists for.
+
+import { cleanup, render, screen } from "@testing-library/react"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import type { QualityTier } from "@/lib/api"
+import { useLocale } from "@/lib/i18n"
+import { ru } from "@/lib/i18n/ru"
+import { useYouTubeStore } from "@/lib/youtubeStore"
+
+vi.mock("@/lib/hooks/useVideoDownload", () => ({
+  useVideoDownload: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    downloadState: { status: "idle", progress: 0 },
+    cancelDownload: vi.fn()
+  })
+}))
+
+const { VideoDownloadButton } = await import("./VideoDownloadButton")
+
+const DURATION = 600
+const TIER: QualityTier = {
+  height: 1080,
+  container: "mp4",
+  filesize: null,
+  fps: null
+}
+
+afterEach(() => {
+  cleanup()
+  useLocale.setState({ locale: "en" })
+  useYouTubeStore.getState().reset()
+})
+
+describe("the video download button", () => {
+  test("says what it does in russian when the locale is russian", () => {
+    useLocale.setState({ locale: "ru" })
+    useYouTubeStore.setState({
+      selectedTier: TIER,
+      videoTimeRange: { start: 0, end: DURATION }
+    })
+
+    render(<VideoDownloadButton maxDuration={DURATION} isVisible />)
+
+    expect(
+      screen.getByRole("button", { name: ru["download.video"] })
+    ).toBeTruthy()
+    expect(screen.getByText(ru["download.mergeHint"])).toBeTruthy()
+  })
+})

--- a/src/main/renderer/src/components/video/VideoDownloadButton.tsx
+++ b/src/main/renderer/src/components/video/VideoDownloadButton.tsx
@@ -11,6 +11,7 @@ import {
   validateTimeRange
 } from "@/lib/api"
 import { useVideoDownload } from "@/lib/hooks/useVideoDownload"
+import { useT } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { isTerminalReason } from "@/lib/downloadOutcome"
 import { cn } from "@/lib/utils"
@@ -41,6 +42,7 @@ export function VideoDownloadButton({
   } = useYouTubeStore()
 
   const videoDownloadMutation = useVideoDownload()
+  const t = useT()
 
   const selectedDuration = videoTimeRange.end - videoTimeRange.start
 
@@ -117,7 +119,7 @@ export function VideoDownloadButton({
             <div className="flex items-center gap-2">
               <Video className="h-4 w-4 text-slate-500 dark:text-slate-500" />
               <span className="text-sm text-slate-600 dark:text-slate-400">
-                Video Quality:
+                {t("card.videoQuality")}
               </span>
             </div>
             <span className="font-medium text-slate-900 dark:text-white">
@@ -131,13 +133,13 @@ export function VideoDownloadButton({
             <div className="flex items-center gap-2">
               <Headphones className="h-4 w-4 text-slate-500 dark:text-slate-500" />
               <span className="text-sm text-slate-600 dark:text-slate-400">
-                Audio Track:
+                {t("card.audioTrack")}
               </span>
             </div>
             <span className="font-medium text-slate-900 dark:text-white">
               {selectedAudioLanguage
                 ? languageName(selectedAudioLanguage)
-                : "Best available"}
+                : t("card.bestAvailable")}
             </span>
           </div>
 
@@ -146,7 +148,7 @@ export function VideoDownloadButton({
           {!isSegmentDownload && selectedTier.filesize && (
             <div className="flex items-center justify-between">
               <span className="text-sm text-slate-600 dark:text-slate-400">
-                Size:
+                {t("card.size")}
               </span>
               <span className="font-medium text-slate-900 dark:text-white">
                 {formatFileSize(selectedTier.filesize)}
@@ -157,7 +159,7 @@ export function VideoDownloadButton({
           {/* Duration */}
           <div className="flex items-center justify-between">
             <span className="text-sm text-slate-600 dark:text-slate-400">
-              Duration:
+              {t("card.duration")}
             </span>
             <span className="font-medium text-slate-900 dark:text-white">
               {formatDuration(selectedDuration)}
@@ -167,7 +169,7 @@ export function VideoDownloadButton({
           {/* Time Range */}
           <div className="flex items-center justify-between">
             <span className="text-sm text-slate-600 dark:text-slate-400">
-              Time Range:
+              {t("card.timeRange")}
             </span>
             <span className="font-medium text-slate-900 dark:text-white">
               {Math.floor(videoTimeRange.start / 60)}:
@@ -183,7 +185,7 @@ export function VideoDownloadButton({
               <div className="flex items-center gap-2">
                 <Scissors className="h-4 w-4 text-slate-500 dark:text-slate-500" />
                 <span className="text-sm text-slate-600 dark:text-slate-400">
-                  Precise Cut:
+                  {t("card.preciseCut")}
                 </span>
               </div>
               <Tooltip>
@@ -199,11 +201,11 @@ export function VideoDownloadButton({
                         : "hover:bg-slate-100 dark:hover:bg-slate-700"
                     )}
                   >
-                    {videoPreciseCut ? "Enabled" : "Disabled"}
+                    {videoPreciseCut ? t("card.enabled") : t("card.disabled")}
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="left">
-                  <p>Turn off for faster download but less precise cuts</p>
+                  <p>{t("card.preciseCutHint")}</p>
                 </TooltipContent>
               </Tooltip>
             </div>
@@ -224,10 +226,10 @@ export function VideoDownloadButton({
       >
         {videoDownloadMutation.isPending ? (
           <>
-            <span className="animate-pulse">Downloading...</span>
+            <span className="animate-pulse">{t("download.inProgress")}</span>
           </>
         ) : (
-          "Download Video"
+          t("download.video")
         )}
       </Button>
 
@@ -235,7 +237,7 @@ export function VideoDownloadButton({
       {videoDownloadMutation.isPending && (
         <DownloadProgressBar
           state={videoDownloadMutation.downloadState}
-          label="video"
+          label={t("media.video")}
           onCancel={videoDownloadMutation.cancelDownload}
         />
       )}
@@ -243,7 +245,7 @@ export function VideoDownloadButton({
       {/* Helper Text */}
       {!videoDownloadMutation.isPending && (
         <div className="text-xs text-slate-500 dark:text-slate-500 text-center">
-          Video and audio will be merged automatically
+          {t("download.mergeHint")}
         </div>
       )}
     </motion.div>

--- a/src/main/renderer/src/components/video/VideoLayout.tsx
+++ b/src/main/renderer/src/components/video/VideoLayout.tsx
@@ -5,12 +5,14 @@ import {
   VideoDetailsCard,
   VideoPlayerFrame
 } from "@/components/video"
+import { useT } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { motion } from "framer-motion"
 import { CompactSearch } from "./CompactSearch"
 
 export function VideoLayout() {
   const { videoInfo, url } = useYouTubeStore()
+  const t = useT()
 
   if (!videoInfo) return null
 
@@ -101,12 +103,11 @@ export function VideoLayout() {
               className="flex-shrink-0 px-1 mb-3"
             >
               <div className="text-xs text-slate-500 dark:text-slate-400 font-space-grotesk">
-                Downloads stored at{" "}
+                {t("layout.downloadsAt")}{" "}
                 <span className="font-mono text-slate-600 dark:text-slate-300">
                   ~/Downloads/Cliply
                 </span>{" "}
-                &nbsp;•&nbsp; Multiple downloads supported, performance may vary
-                with concurrent downlaods.
+                &nbsp;•&nbsp; {t("layout.concurrentNote")}
               </div>
             </motion.div>
 

--- a/src/main/renderer/src/components/video/VideoPlayerFrame.tsx
+++ b/src/main/renderer/src/components/video/VideoPlayerFrame.tsx
@@ -1,4 +1,5 @@
 import { extractVideoId, isYouTubeShorts } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
 
@@ -13,6 +14,7 @@ export function VideoPlayerFrame({
   title,
   className
 }: VideoPlayerFrameProps) {
+  const t = useT()
   const videoId = extractVideoId(url)
   const isShorts = isYouTubeShorts(url)
 
@@ -33,7 +35,9 @@ export function VideoPlayerFrame({
           className
         )}
       >
-        <p className="text-slate-500 dark:text-slate-400">Can't display video</p>
+        <p className="text-slate-500 dark:text-slate-400">
+          {t("player.cantDisplay")}
+        </p>
       </motion.div>
     )
   }

--- a/src/main/renderer/src/components/video/VideoQualityDropdown.tsx
+++ b/src/main/renderer/src/components/video/VideoQualityDropdown.tsx
@@ -1,5 +1,6 @@
 import type { QualityTier } from "@/lib/api"
 import { formatFileSize } from "@/lib/api"
+import { useT } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
@@ -49,6 +50,7 @@ export function VideoQualityDropdown({
   onOpenChange
 }: VideoQualityDropdownProps) {
   const { selectedTier, setSelectedTier } = useYouTubeStore()
+  const t = useT()
 
   // the selection has to be a row of *this* menu, by identity and not by a
   // matching height: a tier object from the last video would otherwise keep
@@ -66,8 +68,8 @@ export function VideoQualityDropdown({
   return (
     <SelectionDropdown
       icon={Video}
-      heading="Video Quality"
-      placeholder="Select video quality..."
+      heading={t("dropdown.videoQuality")}
+      placeholder={t("dropdown.videoQualityPlaceholder")}
       options={tiers}
       selected={selectedTier}
       onSelect={setSelectedTier}
@@ -85,8 +87,7 @@ export function VideoQualityDropdown({
           )}
         >
           <p className="text-sm text-slate-600 dark:text-slate-400">
-            This link has no video streams to download — only audio. The Audio
-            Only tab still works.
+            {t("dropdown.noVideoStreams")}
           </p>
         </div>
       }
@@ -97,13 +98,13 @@ export function VideoQualityDropdown({
             animate={{ opacity: 1 }}
             className="text-sm text-slate-600 dark:text-slate-400"
           >
-            Selected:{" "}
+            {t("dropdown.selected")}{" "}
             <span className="font-medium text-slate-900 dark:text-white">
               {tierLabel(selectedTier)} {selectedTier.container.toUpperCase()}
             </span>
             <span className="text-slate-500 dark:text-slate-500">
               {" "}
-              + best audio
+              {t("dropdown.plusBestAudio")}
             </span>
           </motion.div>
         )

--- a/src/main/renderer/src/components/video/VideoTimeRangeSelector.tsx
+++ b/src/main/renderer/src/components/video/VideoTimeRangeSelector.tsx
@@ -4,6 +4,7 @@ import {
   timeToSeconds,
   validateTimeRange
 } from "@/lib/api"
+import { useT, type Key } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { cn } from "@/lib/utils"
 import { motion } from "framer-motion"
@@ -20,9 +21,10 @@ export function VideoTimeRangeSelector({
   className
 }: VideoTimeRangeSelectorProps) {
   const { videoTimeRange, setVideoTimeRange } = useYouTubeStore()
+  const t = useT()
   const [startTimeInput, setStartTimeInput] = useState("00:00")
   const [endTimeInput, setEndTimeInput] = useState(secondsToTime(maxDuration))
-  const [validationError, setValidationError] = useState<string | null>(null)
+  const [validationError, setValidationError] = useState<Key | null>(null)
 
   // Initialize with full duration
   useEffect(() => {
@@ -71,7 +73,7 @@ export function VideoTimeRangeSelector({
       <div className="flex items-center gap-2">
         <Clock className="h-5 w-5 text-slate-600 dark:text-slate-400" />
         <h3 className="font-medium text-slate-900 dark:text-white">
-          Time Range
+          {t("time.range")}
         </h3>
       </div>
 
@@ -81,7 +83,7 @@ export function VideoTimeRangeSelector({
           {/* Start Time */}
           <div>
             <label className="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-2">
-              Start Time
+              {t("time.start")}
             </label>
             <input
               type="text"
@@ -106,7 +108,7 @@ export function VideoTimeRangeSelector({
           {/* End Time */}
           <div>
             <label className="block text-sm font-medium text-slate-600 dark:text-slate-400 mb-2">
-              End Time
+              {t("time.end")}
             </label>
             <input
               type="text"
@@ -137,7 +139,7 @@ export function VideoTimeRangeSelector({
           animate={{ opacity: 1 }}
           className="text-sm text-red-600 dark:text-red-400 font-medium"
         >
-          {validationError}
+          {t(validationError)}
         </motion.div>
       )}
 
@@ -148,7 +150,7 @@ export function VideoTimeRangeSelector({
           animate={{ opacity: 1 }}
           className="text-sm text-slate-600 dark:text-slate-400"
         >
-          Selected duration:{" "}
+          {t("time.selectedDuration")}{" "}
           <span className="font-medium text-slate-900 dark:text-white">
             {formatDuration(selectedDuration)}
           </span>
@@ -157,7 +159,7 @@ export function VideoTimeRangeSelector({
 
       {/* Helper Text */}
       <p className="text-xs text-slate-500 dark:text-slate-500">
-        Format: MM:SS or HH:MM:SS • Max duration: {secondsToTime(maxDuration)}
+        {t("time.helperShort", { max: secondsToTime(maxDuration) })}
       </p>
     </motion.div>
   )

--- a/src/main/renderer/src/lib/api.ts
+++ b/src/main/renderer/src/lib/api.ts
@@ -1,5 +1,6 @@
 // api client using electron ipc instead of http
 
+import type { Key } from "@/lib/i18n"
 import type { ReportEnvironment } from "@/lib/report"
 
 /**
@@ -108,6 +109,8 @@ export interface CookieStatus {
   hasValidCookies: boolean
   /** why the jar is unusable, written by main. null when it works */
   problem: string | null
+  /** the same verdict as a stable `JAR_*` code, so it can be said in russian */
+  problemCode?: string | null
   status: { lastImport?: string | null; lastTest?: string | null }
 }
 
@@ -132,6 +135,8 @@ export interface CookieTestResult {
   /** youtube turned the cookies down while they were being sent - the one strong negative */
   rejected?: boolean
   note: string
+  /** the note as a stable `JAR_*` or `PROBE_*` code, for the same reason */
+  noteCode?: string | null
 }
 
 export interface VideoInfoResponse {
@@ -248,6 +253,8 @@ export interface ApiError {
   suggestion?: string
   details?: string
   category?: string
+  /** main's own code for the failure, "GENERAL_ERROR" when it has none */
+  code?: string
 }
 
 /**
@@ -271,6 +278,22 @@ export class DownloadError extends Error {
     this.name = "DownloadError"
     this.details = error?.details
     this.category = error?.category
+  }
+}
+
+/**
+ * an import main refused, carrying the code it refused it under
+ *
+ * a bare Error threw the code away, and the dialog would have had to match
+ * main's english sentence to know which refusal it was holding.
+ */
+export class CookieError extends Error {
+  code?: string
+
+  constructor(message: string, code?: string) {
+    super(message)
+    this.name = "CookieError"
+    this.code = code
   }
 }
 
@@ -757,7 +780,10 @@ export const cookiesApi = {
 
     if (!response.success) {
       if (response.error?.message === "No file selected") return null
-      throw new Error(response.error?.message || "couldn't import those cookies")
+      throw new CookieError(
+        response.error?.message || "couldn't import those cookies",
+        response.error?.code
+      )
     }
 
     return response.data ?? null
@@ -856,21 +882,23 @@ export const timeToSeconds = (time: string): number => {
   return parts[0] || 0
 }
 
+// the reason is a translation key rather than a sentence: whoever renders it
+// calls `t()` there, the same way the zod schemas carry their messages
 export const validateTimeRange = (
   start: number,
   end: number,
   duration: number
-): { isValid: boolean; error?: string } => {
+): { isValid: boolean; error?: Key } => {
   if (start < 0) {
-    return { isValid: false, error: "Start time cannot be negative" }
+    return { isValid: false, error: "time.startNegative" }
   }
 
   if (end > duration) {
-    return { isValid: false, error: "End time exceeds video duration" }
+    return { isValid: false, error: "time.endExceeds" }
   }
 
   if (start >= end) {
-    return { isValid: false, error: "End time must be greater than start time" }
+    return { isValid: false, error: "time.endBeforeStart" }
   }
 
   return { isValid: true }

--- a/src/main/renderer/src/lib/hooks/useAudioDownload.ts
+++ b/src/main/renderer/src/lib/hooks/useAudioDownload.ts
@@ -8,6 +8,7 @@ import {
   type DownloadProgress
 } from "@/lib/api"
 import { isTerminalReason, terminalReason } from "@/lib/downloadOutcome"
+import { localizeError, t } from "@/lib/i18n"
 import { reportActions } from "@/lib/reportStore"
 import { showDownloadErrorToast } from "@/lib/toast-utils"
 import { useMutation } from "@tanstack/react-query"
@@ -69,7 +70,7 @@ export const useAudioDownload = () => {
       setDownloadState({
         status: "starting",
         progress: 0,
-        message: "Starting audio download..."
+        message: t("download.startingAudio")
       })
 
       // Correlate on an id we generate here: the listener can then filter from
@@ -104,19 +105,21 @@ export const useAudioDownload = () => {
               indeterminate: progressData.indeterminate,
               message:
                 progressData.error ||
-                `Downloading audio... ${(progressData.progress || 0).toFixed(1)}%`,
+                t("download.audioProgress", {
+                  percent: (progressData.progress || 0).toFixed(1)
+                }),
               outputFile: progressData.filename,
               error: progressData.error
             }))
 
             // Handle completion
             if (progressData.status === "completed") {
-              toast.success("Audio download completed!", {
+              toast.success(t("download.audioCompleted"), {
                 description: progressData.filename
-                  ? `Saved: ${progressData.filename}`
+                  ? t("download.saved", { filename: progressData.filename })
                   : undefined,
                 action: {
-                  label: "Open Folder",
+                  label: t("toast.openFolder"),
                   onClick: () => systemApi.openDownloadFolder()
                 }
               })
@@ -135,8 +138,15 @@ export const useAudioDownload = () => {
                 videoUrl: lastUrlRef.current
               })
               showDownloadErrorToast(
-                "Audio download failed",
-                progressData.error || "Something went wrong. You can send us the details.",
+                t("download.audioFailed"),
+                // the report above keeps main's english; only what is read here
+                // is translated
+                progressData.error
+                  ? localizeError({
+                      message: progressData.error,
+                      category: progressData.category
+                    }).message
+                  : t("download.wentWrong"),
                 progressData.category,
                 "youtube"
               )
@@ -203,7 +213,7 @@ export const useAudioDownload = () => {
         ...prev,
         status: "failed",
         error: error.message,
-        message: `Failed to start download: ${error.message}`
+        message: t("download.startFailed", { message: error.message })
       }))
 
       reportActions.stage({
@@ -215,8 +225,11 @@ export const useAudioDownload = () => {
         videoUrl: lastUrlRef.current
       })
       showDownloadErrorToast(
-        "Audio download failed",
-        error.message,
+        t("download.audioFailed"),
+        localizeError({
+          message: error.message,
+          category: error instanceof DownloadError ? error.category : undefined
+        }).message,
         error instanceof DownloadError ? error.category : undefined,
         "youtube"
       )
@@ -241,7 +254,7 @@ export const useAudioDownload = () => {
         setDownloadState((prev) => ({
           ...prev,
           status: "cancelled",
-          message: "Download cancelled"
+          message: t("download.cancelled")
         }))
 
         // settle the pending mutation so the button never stays stuck
@@ -249,7 +262,7 @@ export const useAudioDownload = () => {
           terminalReason("cancelled", "Download cancelled")
         )
 
-        toast.info("Audio download cancelled")
+        toast.info(t("download.audioCancelled"))
       } catch (error) {
         console.error("Failed to cancel download:", error)
       }

--- a/src/main/renderer/src/lib/hooks/useDownloadPath.ts
+++ b/src/main/renderer/src/lib/hooks/useDownloadPath.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react"
 import { settingsApi, systemApi } from "@/lib/api"
+import { t } from "@/lib/i18n"
 import { useYouTubeStore } from "@/lib/youtubeStore"
 import { showFolderSelectedToast } from "@/lib/toast-utils"
 import { toast } from "sonner"
@@ -26,7 +27,7 @@ export function useDownloadPath() {
       }
     } catch (error) {
       console.error("failed to update download folder:", error)
-      toast.error("failed to update download folder")
+      toast.error(t("folder.updateFailed"))
     } finally {
       setIsLoadingDownloadPath(false)
     }

--- a/src/main/renderer/src/lib/hooks/useMediaSearch.ts
+++ b/src/main/renderer/src/lib/hooks/useMediaSearch.ts
@@ -4,6 +4,8 @@ import { toast } from "sonner"
 
 import { durationBucket, track, urlKind } from "@/lib/analytics"
 import { DownloadError } from "@/lib/api"
+import { en } from "@/lib/i18n/en"
+import { localizeError, t } from "@/lib/i18n"
 import {
   PLATFORM_REGISTRY,
   type PlatformConfig
@@ -80,7 +82,7 @@ export function useMediaSearch(
       config.store.setUrl(data.url)
       const summary = await config.fetchAndStore(data.url)
       setShowMediaDetails(true)
-      toast.success(config.successMessage)
+      toast.success(t(config.successMessage))
 
       track("media_info_loaded", {
         platform,
@@ -134,7 +136,15 @@ function handleSearchError(
   form: UseFormReturn<{ url: string }>
 ) {
   const errorMessage =
-    error instanceof Error ? error.message : config.errorMessages.genericFail
+    error instanceof Error ? error.message : t(config.errorMessages.genericFail)
+
+  // main's sentence is matched in english below, because that is the language it
+  // is written in, and shown in the reader's - which are two different strings
+  // once the locale is russian
+  const shown = localizeError({
+    message: errorMessage,
+    category: error instanceof DownloadError ? error.category : undefined
+  }).message
 
   // checked first, and on the category rather than the wording: this is the one
   // failure here the user can actually fix, and main already decided which it
@@ -146,18 +156,21 @@ function handleSearchError(
   ) {
     // the platform decides which action the toast offers: BOT_DETECTION also
     // catches tiktok and pinterest, and the cookie dialog is youtube's alone
-    showBotDetectionToast(errorMessage, config.id)
-  } else if (errorMessage.includes(config.errorMessages.invalidUrl)) {
-    toast.error(config.errorMessages.invalidUrlToast)
+    showBotDetectionToast(shown, config.id)
+  } else if (errorMessage.includes(en[config.errorMessages.invalidUrl])) {
+    // matched against english on purpose: this sentence came from main, which
+    // stays english so its wording keeps feeding logs and issue bodies. only
+    // what the user is shown gets translated
+    toast.error(t(config.errorMessages.invalidUrlToast))
     form.setError("url", { message: config.errorMessages.invalidUrl })
   } else if (
     errorMessage.includes("unavailable") ||
     errorMessage.includes("not found")
   ) {
-    toast.error(config.errorMessages.unavailable)
+    toast.error(t(config.errorMessages.unavailable))
   } else if (errorMessage.includes("image, not a video")) {
-    toast.error("This is an image, not a video", {
-      description: "Only videos can be downloaded"
+    toast.error(t("error.imageNotVideo"), {
+      description: t("error.imageNotVideoDesc")
     })
   } else if (
     errorMessage.includes("network") ||
@@ -165,8 +178,8 @@ function handleSearchError(
   ) {
     showServerOverwhelmedToast()
   } else {
-    toast.error(config.errorMessages.genericFail, {
-      description: errorMessage
+    toast.error(t(config.errorMessages.genericFail), {
+      description: shown
     })
   }
 

--- a/src/main/renderer/src/lib/hooks/useVideoDownload.ts
+++ b/src/main/renderer/src/lib/hooks/useVideoDownload.ts
@@ -8,6 +8,7 @@ import {
   type VideoDownloadRequest
 } from "@/lib/api"
 import { isTerminalReason, terminalReason } from "@/lib/downloadOutcome"
+import { localizeError, t } from "@/lib/i18n"
 import { reportActions } from "@/lib/reportStore"
 import { showDownloadErrorToast } from "@/lib/toast-utils"
 import { useMutation } from "@tanstack/react-query"
@@ -70,7 +71,7 @@ export const useVideoDownload = () => {
       setDownloadState({
         status: "starting",
         progress: 0,
-        message: "Starting video download..."
+        message: t("download.startingVideo")
       })
 
       // Correlate on an id we generate here: the listener can then filter from
@@ -105,19 +106,21 @@ export const useVideoDownload = () => {
               indeterminate: progressData.indeterminate,
               message:
                 progressData.error ||
-                `Downloading video... ${(progressData.progress || 0).toFixed(1)}%`,
+                t("download.videoProgress", {
+                  percent: (progressData.progress || 0).toFixed(1)
+                }),
               outputFile: progressData.filename,
               error: progressData.error
             }))
 
             // Handle completion
             if (progressData.status === "completed") {
-              toast.success("Video download completed!", {
+              toast.success(t("download.videoCompleted"), {
                 description: progressData.filename
-                  ? `Saved: ${progressData.filename}`
+                  ? t("download.saved", { filename: progressData.filename })
                   : undefined,
                 action: {
-                  label: "Open Folder",
+                  label: t("toast.openFolder"),
                   onClick: () => systemApi.openDownloadFolder()
                 }
               })
@@ -136,8 +139,15 @@ export const useVideoDownload = () => {
                 videoUrl: lastUrlRef.current
               })
               showDownloadErrorToast(
-                "Video download failed",
-                progressData.error || "Something went wrong. You can send us the details.",
+                t("download.videoFailed"),
+                // the report above keeps main's english; only what is read here
+                // is translated
+                progressData.error
+                  ? localizeError({
+                      message: progressData.error,
+                      category: progressData.category
+                    }).message
+                  : t("download.wentWrong"),
                 progressData.category,
                 "youtube"
               )
@@ -203,7 +213,7 @@ export const useVideoDownload = () => {
         ...prev,
         status: "failed",
         error: error.message,
-        message: `Failed to start download: ${error.message}`
+        message: t("download.startFailed", { message: error.message })
       }))
 
       reportActions.stage({
@@ -215,8 +225,11 @@ export const useVideoDownload = () => {
         videoUrl: lastUrlRef.current
       })
       showDownloadErrorToast(
-        "Video download failed",
-        error.message,
+        t("download.videoFailed"),
+        localizeError({
+          message: error.message,
+          category: error instanceof DownloadError ? error.category : undefined
+        }).message,
         error instanceof DownloadError ? error.category : undefined,
         "youtube"
       )
@@ -241,7 +254,7 @@ export const useVideoDownload = () => {
         setDownloadState((prev) => ({
           ...prev,
           status: "cancelled",
-          message: "Download cancelled"
+          message: t("download.cancelled")
         }))
 
         // settle the pending mutation so the button never stays stuck
@@ -249,7 +262,7 @@ export const useVideoDownload = () => {
           terminalReason("cancelled", "Download cancelled")
         )
 
-        toast.info("Video download cancelled")
+        toast.info(t("download.videoCancelled"))
       } catch (error) {
         console.error("Failed to cancel download:", error)
       }

--- a/src/main/renderer/src/lib/i18n/en.ts
+++ b/src/main/renderer/src/lib/i18n/en.ts
@@ -1,0 +1,329 @@
+/**
+ * every string the ui says, in english
+ *
+ * english is the source of truth: `ru.ts` is typed against this object, so a
+ * key added here without a translation is a compile error rather than a blank
+ * label someone notices in production.
+ *
+ * `{name}` is substituted from `t`'s params. a value containing `|` is a plural
+ * set, its forms in the order `Intl.PluralRules` lists for the language -
+ * english `one|other`, russian `one|few|many`.
+ */
+export const en = {
+  "hero.tagline": "download stuff effortlessly",
+  "hero.cookieHint": "having trouble with downloads? try cookies",
+  "hero.footerFree":
+    "cliply is free and open source. just one guy tries to keep it running.",
+  "hero.footerUseful": "if it's useful,",
+  "hero.donate": "buy me a coffee",
+  "hero.updateCheckFailed": "Check Failed",
+  "hero.updateCheckFailedBody": "Failed to check for updates",
+
+  "menu.about": "about",
+  "menu.update": "update",
+  "menu.donate": "donate",
+  "menu.github": "github",
+
+  "url.placeholder": "paste video url here...",
+  // the details screen asks for a replacement link
+  "url.replacePlaceholder": "Enter new video URL...",
+  "url.loading": "\u{1F40B} getting video information",
+  "url.loaded": "Video information loaded successfully!",
+  "url.selectFolder": "Select folder",
+  "url.pickerBusy": "Wait for the current link to finish",
+  "url.youtubeHelper":
+    "supports youtube videos & shorts from youtube.com and youtu.be",
+  "url.pinterestHelper":
+    "supports pin.it and pinterest.com/pin links, any country domain",
+  "url.tiktokHelper":
+    "supports tiktok.com/@user/video/ID, vm.tiktok.com, and vt.tiktok.com links",
+
+  "error.imageNotVideo": "This is an image, not a video",
+  "error.imageNotVideoDesc": "Only videos can be downloaded",
+  "error.youtubeUrl": "Invalid YouTube URL",
+  "error.pinterestUrl": "Invalid Pinterest URL",
+  "error.tiktokUrl": "Invalid TikTok URL",
+  "error.unavailable": "This video is not available for download",
+  "error.infoFailed": "Failed to get video information",
+  "error.tiktokBlocked":
+    "TikTok blocked this request — please try again in a moment",
+
+  "validation.youtubeRequired": "Please enter a YouTube URL",
+  "validation.youtubeInvalid": "Please enter a valid YouTube URL",
+  "validation.pinterestRequired": "Please enter a Pinterest URL",
+  "validation.pinterestInvalid": "Please enter a valid Pinterest URL",
+  "validation.tiktokRequired": "Please enter a TikTok URL",
+  "validation.tiktokInvalid": "Please enter a valid TikTok URL",
+
+  "theme.toggle": "Toggle theme",
+
+  "folder.updated": "Download folder updated!",
+  "folder.updateFailed": "failed to update download folder",
+
+  "cookies.count": "{n} cookie|{n} cookies",
+  "cookies.title": "youtube cookies",
+  "cookies.description":
+    "youtube sometimes decides this machine looks like a bot, usually because of your network rather than anything you did. a cookie file from your own browser is how you tell it otherwise.",
+  "cookies.privacy":
+    "you sign in to youtube in your own browser, never to cliply. everything stays on this device, we never upload any of it, and you can delete it whenever you want.",
+  "cookies.ytdlpCredit": "it's the standard process yt-dlp recommends.",
+  "cookies.readGuide": "read their guide",
+  "cookies.signedIn": "signed in",
+  "cookies.howTo": "here's how to import them",
+  // split so the count can sit between the halves, as it does in english
+  "cookies.stillHere": "your file is still here",
+  "cookies.stillHereRest":
+    ", it just stopped working. nothing got deleted. grab a fresh export and import it over the top.",
+  "cookies.importedToday": "imported today",
+  "cookies.importedYesterday": "imported yesterday",
+  "cookies.importedDaysAgo": "imported {n} day ago|imported {n} days ago",
+
+  "cookies.step1": "install",
+  "cookies.step1or": "(chrome) or",
+  "cookies.step1firefox": "(firefox)",
+  "cookies.step2": "open youtube in your browser and sign in",
+  "cookies.step2note":
+    "use a spare account if you have one. youtube has been known to ban accounts it catches using downloaders.",
+  "cookies.step3": "in that same tab, go to",
+  "cookies.step3note":
+    "parks the tab somewhere youtube isn't handing out fresh cookies.",
+  "cookies.copyHint": "click to copy",
+  "cookies.copied": "copied, paste it there",
+  "cookies.step4": "click the extension's icon, then hit",
+  // the extension's own button, which it labels in english whatever the browser
+  "cookies.step4export": "export",
+  "cookies.step4note":
+    "up by your address bar, sometimes under the puzzle piece. saves a .txt to your downloads.",
+  "cookies.step5": "close that youtube tab",
+  "cookies.step5note":
+    "youtube keeps refreshing cookies on open youtube tabs, and every refresh ages your export. closing it is what makes these last.",
+  "cookies.step6": "import that file here",
+
+  "cookies.importing": "importing…",
+  "cookies.replace": "replace…",
+  "cookies.tryAgain": "try again…",
+  "cookies.import": "import cookies…",
+  "cookies.testing": "testing…",
+  "cookies.test": "test",
+  "cookies.remove": "remove",
+
+  "cookies.footerSignedIn":
+    "youtube rotates these out eventually. when it does, cliply will say so right here.",
+  "cookies.footer":
+    "nothing here is sent anywhere. the file only ever goes to youtube, from your own machine.",
+
+  "cookies.imported": "cookies imported",
+  "cookies.importedDesc": "youtube will see you as signed in from now on.",
+  "cookies.notSignedIn": "imported, but not signed in",
+  "cookies.notSignedInDesc": "these cookies won't sign you in.",
+  "cookies.importFailed": "couldn't import that file",
+  "cookies.importFailedDesc": "couldn't import cookies",
+  "cookies.turnedDown": "youtube turned these down",
+  "cookies.lookFine": "cookies look fine",
+  "cookies.notUsable": "cookies aren't usable",
+  "cookies.testFailed": "couldn't test the cookies",
+  "cookies.removeFailed": "couldn't remove the cookies",
+  "cookies.removeFailedDesc": "they're still on this machine.",
+  "cookies.copyFailed": "couldn't copy that",
+  "cookies.copyFailedDesc": "type youtube.com/robots.txt into that tab instead.",
+
+  "toast.overwhelmed": "we're overwhelmed",
+  "toast.openFolder": "Open Folder",
+  "toast.report": "report",
+  "toast.fixWithCookies": "fix with cookies",
+  "toast.botCookies": "signing in with a throwaway account usually clears this.",
+  "toast.botGeneric": "this site wants us to prove we're not a bot.",
+  "toast.audioDone": "Audio downloaded successfully!",
+  "toast.videoDone": "Video downloaded successfully!",
+  "toast.audioDoneDesc": "Your audio file has been downloaded to your device.",
+  "toast.videoDoneDesc": "Your video file has been downloaded to your device.",
+
+  "download.startingAudio": "Starting audio download...",
+  "download.startingVideo": "Starting video download...",
+  "download.audioProgress": "Downloading audio... {percent}%",
+  "download.videoProgress": "Downloading video... {percent}%",
+  "download.audioCompleted": "Audio download completed!",
+  "download.videoCompleted": "Video download completed!",
+  "download.saved": "Saved: {filename}",
+  "download.audioFailed": "Audio download failed",
+  "download.videoFailed": "Video download failed",
+  // the one-button platforms, which do not say which kind of download it was
+  "download.failed": "Download failed",
+  "download.wentWrong": "Something went wrong. You can send us the details.",
+  "download.startFailed": "Failed to start download: {message}",
+  "download.cancelled": "Download cancelled",
+  "download.audioCancelled": "Audio download cancelled",
+  "download.videoCancelled": "Video download cancelled",
+  "download.complete": "Download complete!",
+  "download.video": "Download Video",
+  "download.audio": "Download Audio",
+  "download.inProgress": "Downloading...",
+  "download.mergeHint": "Video and audio will be merged automatically",
+  "download.audioHint":
+    "Audio will be downloaded with the selected time range and format",
+
+  "card.tabVideo": "Video Download",
+  "card.tabAudio": "Audio Only",
+  "card.videoIntro": "Download video with automatically paired audio",
+  "card.audioIntro": "Extract audio from the video with custom time range",
+  "card.summary": "Download Summary",
+  "card.uploader": "Uploader:",
+  "card.duration": "Duration:",
+  "card.size": "Size:",
+  "card.format": "Format:",
+  "card.language": "Language:",
+  "card.timeRange": "Time Range:",
+  "card.videoQuality": "Video Quality:",
+  "card.audioTrack": "Audio Track:",
+  "card.bestAvailable": "Best available",
+  "card.preciseCut": "Precise Cut:",
+  "card.enabled": "Enabled",
+  "card.disabled": "Disabled",
+  "card.preciseCutHint": "Turn off for faster download but less precise cuts",
+  "card.pinterestSubtitle": "Best available quality, saved as MP4.",
+  "card.tiktokSubtitle":
+    "Best available quality, saved as MP4. No watermark.",
+
+  "dropdown.videoQuality": "Video Quality",
+  "dropdown.videoQualityPlaceholder": "Select video quality...",
+  "dropdown.audioFormat": "Audio Format",
+  "dropdown.audioFormatPlaceholder": "Select audio format...",
+  "dropdown.audioLanguage": "Audio Language",
+  "dropdown.audioLanguagePlaceholder": "Select audio language...",
+  "dropdown.selected": "Selected:",
+  "dropdown.plusBestAudio": "+ best audio",
+  "dropdown.original": "Original",
+  "dropdown.noVideoStreams":
+    "This link has no video streams to download — only audio. The Audio Only tab still works.",
+
+  // the container names are the same word everywhere; they sit in the
+  // dictionary only so the row beside them can be typed as a key
+  "format.mp3": "MP3",
+  "format.m4a": "M4A",
+  "format.mp3Detail": "Converted · plays everywhere",
+  "format.m4aDetail": "AAC · converted",
+  "format.originalDetail": "Source quality, no re-encode · usually WEBM/Opus",
+
+  "time.selection": "Time Range Selection",
+  "time.range": "Time Range",
+  "time.start": "Start Time",
+  "time.end": "End Time",
+  "time.selectedDuration": "Selected duration:",
+  "time.helper": "Use MM:SS or HH:MM:SS format. Max duration: {max}",
+  "time.helperShort": "Format: MM:SS or HH:MM:SS • Max duration: {max}",
+  "time.invalid": "Invalid time range",
+  "time.startNegative": "Start time cannot be negative",
+  "time.endExceeds": "End time exceeds video duration",
+  "time.endBeforeStart": "End time must be greater than start time",
+
+  // the noun a progress line is about, interpolated into the lines below
+  "media.video": "video",
+  "media.audio": "audio",
+  "progress.downloading": "Downloading {label}",
+  "progress.processing": "Processing {label}",
+  "progress.startingUp": "Starting up",
+  "progress.trimming": "Progress isn't reported while trimming",
+  "progress.stop": "Stop",
+  "progress.stopTitle": "Stop this download",
+  // what a bar with no position tells assistive tech
+  "progress.working": "Working",
+
+  "feedback.title": "Help us improve",
+  "feedback.subtitle": "Request a feature",
+  "feedback.cta": "tap me :)",
+
+  "layout.downloadsAt": "Downloads stored at",
+  "layout.concurrentNote":
+    "Multiple downloads supported, performance may vary with concurrent downloads.",
+
+  "thumb.unavailable": "Thumbnail unavailable",
+  "thumb.viewOn": "View on {name}",
+  "thumb.openFailed": "Could not open {name} link",
+  "player.cantDisplay": "Can't display video",
+
+  // version numbers and release notes are data, so they stay where they are
+  "update.available": "Update Available",
+  "update.macManual": "Version {version} requires manual download on Mac",
+  "update.download": "Download",
+  "update.downloadingTitle": "Update Downloading",
+  "update.autoDownloading":
+    "Version {version} is downloading automatically in the background",
+  "update.readyToDownload": "Version {version} is ready to download",
+  "update.upToDate": "App is up to date",
+  "update.upToDateDesc": "You're running the latest version",
+  "update.progress": "Downloading Update: {percent}%",
+  "update.inBackground": "Downloading in background...",
+  "update.readyToInstallToast": "Update Ready to Install!",
+  "update.downloadedDesc":
+    "Version {version} has been downloaded successfully. It will install when you close the app.",
+  "update.installNow": "Install Now",
+  "update.checking": "Checking for updates...",
+  "update.error": "Update Error",
+  "update.preparing": "Preparing download...",
+  "update.preparingDesc": "Initializing update download",
+  "update.started": "Download Started",
+  "update.startedDesc":
+    "Update is downloading in the background. You can continue using the app.",
+  // title case, unlike the download card's own "Download failed"
+  "update.downloadFailed": "Download Failed",
+  "update.downloadFailedDesc": "Failed to download update",
+  "update.checkConnection":
+    "Please try again or check your internet connection",
+  "update.installing": "Installing Update",
+  "update.installingDesc": "The app will close and reopen with the new version",
+  "update.installFailed": "Installation Failed",
+  "update.installFailedDesc": "Please try downloading the update again",
+
+  "update.cardDownloading": "Downloading Update",
+  "update.cardProgress": "Version {version} • {percent}% complete",
+  "update.cardReady": "Update Ready",
+  "update.cardReadyDesc": "Version {version} is ready to install",
+  "update.installRestart": "Install & Restart",
+  "update.tryAgain": "Try Again",
+  "update.importantUpdates": "Check for Important Updates",
+
+  "update.macDesc":
+    "We can't auto-update on Mac. Click 'Learn Why' to find out more.",
+  "update.newVersion": "A new version of Cliply is available.",
+  "update.version": "Version {version}",
+  "update.released": "Released {date}",
+  "update.later": "Later",
+  "update.learnWhy": "Learn Why",
+  "update.downloadFromGithub": "Download from GitHub",
+  "update.downloadUpdate": "Download Update",
+  "update.readyToInstall": "Update Ready to Install",
+  "update.readyToInstallDesc":
+    "The update has been downloaded and is ready to install. The app will restart automatically.",
+  "update.whenReady": "Ready to install when you're ready",
+
+  // only the dialog's own chrome. the issue this sends is written in english,
+  // because the maintainers who read it are
+  "report.title": "Report an issue",
+  "report.description":
+    "This opens a pre-filled draft issue on GitHub in your browser. Look it over there, then publish it when you're ready.",
+  "report.whatWentWrong": "What went wrong",
+  "report.yourSetup": "Your setup, attached as-is",
+  "report.technicalDetails": "Technical details we'll attach",
+  "report.show": "show",
+  "report.notes": "Anything you were doing when it broke?",
+  "report.notesPlaceholder": "Optional, but it helps us track it down faster.",
+  "report.includeLink": "Include the link I was downloading",
+  "report.notNow": "Not now",
+  "report.openOnGithub": "Open on GitHub",
+  "report.opening": "Opening GitHub",
+  "report.trimmed":
+    "We trimmed the logs to fit. The full report is on your clipboard.",
+  "report.reviewIt": "Review the pre-filled issue and hit submit.",
+  "report.browserFailed": "Couldn't open your browser",
+  "report.browserFailedDesc":
+    "The full report is on your clipboard. Paste it at github.com/Cliply/Cliply/issues/new",
+
+  // main owns which download counts as a milestone, so the number is data
+  "support.title": "that's {n} downloads",
+  "support.description":
+    "cliply is free, has no ads, and doesn't track you. it's built and kept working by one person in their spare time, mostly against youtube changing things on purpose.",
+  "support.ask": "if it saved you some time, a coffee helps.",
+  "support.decline": "no thanks"
+} as const
+
+export type Key = keyof typeof en

--- a/src/main/renderer/src/lib/i18n/i18n.test.ts
+++ b/src/main/renderer/src/lib/i18n/i18n.test.ts
@@ -1,0 +1,303 @@
+// @vitest-environment jsdom
+//
+// the translation layer is 60 lines with no library under it, so the things
+// that would normally be someone else's problem - a key that exists in one
+// dictionary and not the other, russian's third plural form, a stored choice
+// losing to the system locale - are ours.
+
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import { en } from "./en"
+import { ru } from "./ru"
+
+const freshStore = async () => {
+  vi.resetModules()
+
+  return import("./index")
+}
+
+// node 25 defines a `localStorage` global with none of the methods on it, and
+// it shadows jsdom's, so the real one is not reachable here. an explicit stub
+// is clearer anyway: each test says what was on disk when the app started
+const memoryStorage = (seed?: string) => {
+  const entries = new Map<string, string>(
+    seed === undefined ? [] : [["cliply-locale", seed]]
+  )
+
+  const storage = {
+    length: 0,
+    key: () => null,
+    clear: () => entries.clear(),
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => void entries.set(key, value),
+    removeItem: (key: string) => void entries.delete(key)
+  }
+  vi.stubGlobal("localStorage", storage)
+
+  return storage
+}
+
+beforeEach(() => {
+  memoryStorage()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+// ru.ts is `Record<Key, string>`, so tsc already refuses a missing key. this
+// catches the other direction, and catches it when someone reaches for a cast
+describe("the two dictionaries", () => {
+  test("hold exactly the same keys", () => {
+    expect(Object.keys(ru).sort()).toEqual(Object.keys(en).sort())
+  })
+
+  test("leave no value empty", () => {
+    expect(Object.entries(ru).filter(([, value]) => !value.trim())).toEqual([])
+  })
+
+  // a russian plural set that forgot a form would silently render the wrong
+  // one, since `t` falls back to the last
+  test("give every english plural set three forms in russian", () => {
+    for (const [key, value] of Object.entries(en)) {
+      if (!value.includes("|")) continue
+
+      expect([key, value.split("|").length]).toEqual([key, 2])
+      expect([key, ru[key as keyof typeof en].split("|").length]).toEqual([
+        key,
+        3
+      ])
+    }
+  })
+})
+
+describe("detectLocale", () => {
+  test.each([
+    ["ru-RU", "ru"],
+    ["ru", "ru"],
+    ["RU", "ru"],
+    ["en-GB", "en"],
+    // ukrainian is its own language; the toggle is how a ukrainian speaker who
+    // reads russian gets there
+    ["uk", "en"],
+    [undefined, "en"]
+  ])("%s resolves to %s", async (language, expected) => {
+    const { detectLocale } = await freshStore()
+
+    expect(detectLocale(language)).toBe(expected)
+  })
+})
+
+describe("the locale the store starts on", () => {
+  test("follows the system when nothing was chosen before", async () => {
+    vi.stubGlobal("navigator", { language: "ru-RU" })
+
+    const { useLocale } = await freshStore()
+
+    expect(useLocale.getState().locale).toBe("ru")
+  })
+
+  test("prefers a stored choice over the system", async () => {
+    memoryStorage("en")
+    vi.stubGlobal("navigator", { language: "ru-RU" })
+
+    const { useLocale } = await freshStore()
+
+    expect(useLocale.getState().locale).toBe("en")
+  })
+
+  test("ignores a stored value that is not a locale", async () => {
+    memoryStorage("kl")
+    vi.stubGlobal("navigator", { language: "ru-RU" })
+
+    const { useLocale } = await freshStore()
+
+    expect(useLocale.getState().locale).toBe("ru")
+  })
+
+  // no storage at all, which is what running outside a browser looks like
+  test("survives having nowhere to read from", async () => {
+    vi.stubGlobal("localStorage", undefined)
+    vi.stubGlobal("navigator", { language: "ru-RU" })
+
+    const { useLocale } = await freshStore()
+
+    expect(useLocale.getState().locale).toBe("ru")
+    expect(() => useLocale.getState().setLocale("en")).not.toThrow()
+  })
+
+  test("records the choice for the next launch, and on <html>", async () => {
+    const storage = memoryStorage()
+    const { useLocale } = await freshStore()
+
+    useLocale.getState().setLocale("ru")
+
+    expect(storage.getItem("cliply-locale")).toBe("ru")
+    expect(document.documentElement.lang).toBe("ru")
+  })
+})
+
+describe("t", () => {
+  test("returns the dictionary for the current locale", async () => {
+    const { t, useLocale } = await freshStore()
+
+    expect(t("hero.tagline")).toBe(en["hero.tagline"])
+
+    useLocale.getState().setLocale("ru")
+
+    expect(t("hero.tagline")).toBe(ru["hero.tagline"])
+  })
+
+  test("substitutes params by name", async () => {
+    const { t } = await freshStore()
+
+    expect(t("cookies.count", { n: 4 })).toBe("4 cookies")
+  })
+
+  // english has two forms, so `other` covers everything that is not exactly 1
+  test.each([
+    [1, "1 cookie"],
+    [0, "0 cookies"],
+    [2, "2 cookies"]
+  ])("picks the english form for %i", async (n, expected) => {
+    const { t } = await freshStore()
+
+    expect(t("cookies.count", { n })).toBe(expected)
+  })
+
+  // russian agreement is on the last digit, not the magnitude: 21 takes the
+  // same form as 1, 22 the same as 2, and everything from 5 to 20 takes the
+  // third
+  //
+  // asked of the day count rather than the cookie count: `cookies.count` keeps
+  // the word latin and undeclined, so its three forms are identical and would
+  // pass this whichever one the selector reached for
+  test.each([
+    [1, "импортировано 1 день назад"],
+    [2, "импортировано 2 дня назад"],
+    [5, "импортировано 5 дней назад"],
+    [0, "импортировано 0 дней назад"],
+    [21, "импортировано 21 день назад"],
+    [22, "импортировано 22 дня назад"],
+    [25, "импортировано 25 дней назад"]
+  ])("picks the russian form for %i", async (n, expected) => {
+    const { t, useLocale } = await freshStore()
+    useLocale.getState().setLocale("ru")
+
+    expect(t("cookies.importedDaysAgo", { n })).toBe(expected)
+  })
+
+  // russian's `other` is for fractions, which no count of ours ever is. it has
+  // no form in the dictionary, so it must not render an empty string
+  test("falls back to the last form for an unlisted category", async () => {
+    const { t, useLocale } = await freshStore()
+    useLocale.getState().setLocale("ru")
+
+    expect(t("cookies.importedDaysAgo", { n: 1.5 })).toBe(
+      "импортировано 1.5 дней назад"
+    )
+  })
+
+  // the cookie count is the other shape: latin, undeclined, and the same in
+  // every form, which is the thing that would silently rot if someone
+  // "corrected" it back into a declined russian noun
+  test.each([[1], [2], [5], [21]])(
+    "counts cookies in latin whatever the number, for %i",
+    async (n) => {
+      const { t, useLocale } = await freshStore()
+      useLocale.getState().setLocale("ru")
+
+      expect(t("cookies.count", { n })).toBe(`${n} cookies`)
+    }
+  )
+})
+
+/**
+ * main keeps its english - it is what the logs, the analytics and the issue
+ * bodies carry, and maintainers read those - so the translation is an overlay
+ * applied at the one point the text becomes a toast. Which means the failure
+ * mode that matters is a category or code this dictionary has not caught up
+ * with: it must fall through to main's sentence rather than to a blank.
+ */
+describe("localizeError", () => {
+  const blocked = {
+    message: "YouTube asked us to confirm you're not a bot.",
+    suggestion: "Import your YouTube cookies from Settings and try again.",
+    category: "BOT_DETECTION"
+  }
+
+  test("leaves an english reader with main's own wording", async () => {
+    const { localizeError } = await freshStore()
+
+    expect(localizeError(blocked)).toBe(blocked)
+  })
+
+  test("swaps both sentences for a category it knows", async () => {
+    const { localizeError, useLocale } = await freshStore()
+    useLocale.getState().setLocale("ru")
+
+    expect(localizeError(blocked)).toEqual({
+      message: "YouTube просит подтвердить, что вы не бот.",
+      suggestion: "импортируйте cookies YouTube в настройках и попробуйте снова.",
+      category: "BOT_DETECTION"
+    })
+  })
+
+  test.each([["SOMETHING_NEW"], [undefined]])(
+    "hands back %s untouched",
+    async (category) => {
+      const { localizeError, useLocale } = await freshStore()
+      useLocale.getState().setLocale("ru")
+
+      const error = { message: "main said something new", category }
+
+      expect(localizeError(error)).toBe(error)
+    }
+  )
+
+  // ru.ts has an entry per key of ERROR_METADATA and TERMINAL_ERRORS, and a
+  // category with only half a translation would show a russian message above an
+  // english suggestion
+  test("gives every russian entry both halves", async () => {
+    const { ruErrors } = await import("./ru")
+
+    expect(
+      Object.entries(ruErrors).filter(
+        ([, value]) => !value?.message.trim() || !value?.suggestion.trim()
+      )
+    ).toEqual([])
+  })
+})
+
+// the same overlay for main's cookie sentences, which travel with a code rather
+// than a taxonomy category
+describe("localizeCode", () => {
+  test("keeps main's sentence for an english reader", async () => {
+    const { localizeCode } = await freshStore()
+
+    expect(localizeCode("JAR_NOTHING_IMPORTED", "nothing imported yet")).toBe(
+      "nothing imported yet"
+    )
+  })
+
+  test("says the russian one when the code is known", async () => {
+    const { localizeCode, useLocale } = await freshStore()
+    useLocale.getState().setLocale("ru")
+
+    expect(localizeCode("JAR_NOTHING_IMPORTED", "nothing imported yet")).toBe(
+      "пока ничего не импортировано"
+    )
+  })
+
+  test.each([["JAR_SOMETHING_NEW"], [null], [undefined]])(
+    "falls back to main's english for %s",
+    async (code) => {
+      const { localizeCode, useLocale } = await freshStore()
+      useLocale.getState().setLocale("ru")
+
+      expect(localizeCode(code, "main said something new")).toBe(
+        "main said something new"
+      )
+    }
+  )
+})

--- a/src/main/renderer/src/lib/i18n/index.ts
+++ b/src/main/renderer/src/lib/i18n/index.ts
@@ -1,0 +1,115 @@
+import { create } from "zustand"
+
+import { en, type Key } from "./en"
+import { ru, ruCodes, ruErrors } from "./ru"
+
+export type { Key }
+export type Locale = "en" | "ru"
+
+const STORAGE_KEY = "cliply-locale"
+
+// the categories Intl.PluralRules can return for each language, in the order a
+// dictionary value lists its forms
+const PLURAL_FORMS: Record<Locale, string[]> = {
+  en: ["one", "other"],
+  ru: ["one", "few", "many"]
+}
+
+export const detectLocale = (language: string | undefined): Locale =>
+  language?.toLowerCase().startsWith("ru") ? "ru" : "en"
+
+/**
+ * both guarded, because this module loads outside a browser too.
+ *
+ * feature-detected rather than `typeof window`: node defines a `localStorage`
+ * global of its own that has none of the methods, and it shadows the one the
+ * test environment installs. anything without `getItem` is not storage.
+ */
+const store = (): Storage | undefined => {
+  const candidate = globalThis.localStorage
+
+  return typeof candidate?.getItem === "function" ? candidate : undefined
+}
+
+const setHtmlLang = (locale: Locale) => {
+  if (typeof document !== "undefined") document.documentElement.lang = locale
+}
+
+export const useLocale = create<{
+  locale: Locale
+  setLocale: (locale: Locale) => void
+}>((set) => {
+  const stored = store()?.getItem(STORAGE_KEY)
+  const locale: Locale =
+    stored === "en" || stored === "ru"
+      ? stored
+      : detectLocale(globalThis.navigator?.language)
+  setHtmlLang(locale)
+
+  return {
+    locale,
+    setLocale: (next) => {
+      store()?.setItem(STORAGE_KEY, next)
+      setHtmlLang(next)
+      set({ locale: next })
+    }
+  }
+})
+
+/**
+ * translate. reads the locale from the store rather than from react, so hooks
+ * and plain modules like `toast-utils` can call it too.
+ */
+export function t(key: Key, params?: Record<string, string | number>): string {
+  const locale = useLocale.getState().locale
+  const dict: Record<string, string> = locale === "ru" ? ru : en
+  let value = dict[key] ?? key
+
+  if (value.includes("|")) {
+    const forms = value.split("|")
+    const category = new Intl.PluralRules(locale).select(Number(params?.n))
+    // an unlisted category (russian `other`, for fractions) takes the last form
+    value =
+      forms[PLURAL_FORMS[locale].indexOf(category)] ?? forms[forms.length - 1]
+  }
+
+  return params
+    ? value.replace(/\{(\w+)\}/g, (whole, name) => String(params[name] ?? whole))
+    : value
+}
+
+/**
+ * main's wording for a failure, in the reader's language
+ *
+ * main stays english - its sentences are what the logs, analytics and issue
+ * bodies carry - so the swap happens here, at the one place the text becomes a
+ * toast. an english reader, or a category `ruErrors` has no entry for, gets
+ * exactly what main sent.
+ */
+export function localizeError<
+  T extends { message: string; suggestion?: string; category?: string }
+>(error: T): T {
+  const russian =
+    useLocale.getState().locale === "ru" && error.category
+      ? ruErrors[error.category]
+      : undefined
+
+  return russian ? { ...error, ...russian } : error
+}
+
+/** the same swap for main's cookie sentences, which travel with a code */
+export function localizeCode(
+  code: string | null | undefined,
+  english: string
+): string {
+  const russian =
+    useLocale.getState().locale === "ru" && code ? ruCodes[code] : undefined
+
+  return russian ?? english
+}
+
+/** `t`, plus a subscription so the component re-renders when the locale flips */
+export function useT() {
+  useLocale((s) => s.locale)
+  return t
+}

--- a/src/main/renderer/src/lib/i18n/ru.ts
+++ b/src/main/renderer/src/lib/i18n/ru.ts
@@ -1,0 +1,460 @@
+import type { Key } from "./en"
+
+/**
+ * the same strings in russian
+ *
+ * `Record<Key, string>` rather than a loose object: a key that english has and
+ * this file does not is a compile error, and a key here that english dropped is
+ * one too. product names stay latin - YouTube, TikTok, Pinterest, cookies.
+ */
+export const ru: Record<Key, string> = {
+  "hero.tagline": "скачивайте без лишних хлопот",
+  "hero.cookieHint": "не качается? попробуйте cookies",
+  "hero.footerFree":
+    "cliply бесплатный и с открытым кодом. его поддерживает один человек.",
+  "hero.footerUseful": "если пригодился,",
+  "hero.donate": "угостите его кофе",
+  "hero.updateCheckFailed": "проверка не удалась",
+  "hero.updateCheckFailedBody": "не удалось проверить обновления",
+
+  "menu.about": "о приложении",
+  "menu.update": "обновить",
+  "menu.donate": "поддержать",
+  "menu.github": "github",
+
+  "url.placeholder": "вставьте ссылку на видео...",
+  "url.replacePlaceholder": "вставьте другую ссылку...",
+  "url.loading": "\u{1F40B} получаем информацию о видео",
+  "url.loaded": "информация о видео загружена",
+  "url.selectFolder": "выбрать папку",
+  "url.pickerBusy": "дождитесь обработки текущей ссылки",
+  "url.youtubeHelper": "поддерживаются видео и shorts с youtube.com и youtu.be",
+  "url.pinterestHelper":
+    "поддерживаются ссылки pin.it и pinterest.com/pin, любой домен страны",
+  "url.tiktokHelper":
+    "поддерживаются ссылки tiktok.com/@user/video/ID, vm.tiktok.com и vt.tiktok.com",
+
+  "error.imageNotVideo": "это изображение, а не видео",
+  "error.imageNotVideoDesc": "скачивать можно только видео",
+  "error.youtubeUrl": "неверная ссылка на YouTube",
+  "error.pinterestUrl": "неверная ссылка на Pinterest",
+  "error.tiktokUrl": "неверная ссылка на TikTok",
+  "error.unavailable": "это видео недоступно для скачивания",
+  "error.infoFailed": "не удалось получить информацию о видео",
+  "error.tiktokBlocked": "TikTok заблокировал запрос, попробуйте через минуту",
+
+  "validation.youtubeRequired": "введите ссылку на YouTube",
+  "validation.youtubeInvalid": "введите корректную ссылку на YouTube",
+  "validation.pinterestRequired": "введите ссылку на Pinterest",
+  "validation.pinterestInvalid": "введите корректную ссылку на Pinterest",
+  "validation.tiktokRequired": "введите ссылку на TikTok",
+  "validation.tiktokInvalid": "введите корректную ссылку на TikTok",
+
+  "theme.toggle": "переключить тему",
+
+  "folder.updated": "папка для загрузок обновлена",
+  "folder.updateFailed": "не удалось изменить папку для загрузок",
+
+  // cookies are counted, not the file holding them, and the word stays latin
+  // and undeclined - so all three forms are the same one
+  "cookies.count": "{n} cookies|{n} cookies|{n} cookies",
+  "cookies.title": "cookies для YouTube",
+  "cookies.description":
+    "YouTube иногда решает, что этот компьютер похож на бота, обычно из-за вашей сети, а не из-за ваших действий. файл с cookies из вашего браузера убеждает его в обратном.",
+  "cookies.privacy":
+    "вы входите в YouTube в своём браузере, а не в cliply. всё остаётся на этом устройстве, мы ничего никуда не загружаем, и вы можете удалить это в любой момент.",
+  "cookies.ytdlpCredit": "это стандартный способ, который рекомендует yt-dlp.",
+  "cookies.readGuide": "читать инструкцию",
+  "cookies.signedIn": "вы вошли",
+  "cookies.howTo": "вот как их импортировать",
+  "cookies.stillHere": "ваш файл на месте",
+  "cookies.stillHereRest":
+    ", он просто перестал работать. ничего не удалено. сделайте свежий экспорт и импортируйте его поверх.",
+  "cookies.importedToday": "импортировано сегодня",
+  "cookies.importedYesterday": "импортировано вчера",
+  "cookies.importedDaysAgo":
+    "импортировано {n} день назад|импортировано {n} дня назад|импортировано {n} дней назад",
+
+  "cookies.step1": "установите",
+  "cookies.step1or": "(chrome) или",
+  "cookies.step1firefox": "(firefox)",
+  "cookies.step2": "откройте YouTube в браузере и войдите",
+  "cookies.step2note":
+    "используйте запасной аккаунт, если он есть. YouTube иногда блокирует аккаунты, замеченные за использованием загрузчиков.",
+  "cookies.step3": "в этой же вкладке откройте",
+  "cookies.step3note":
+    "так вкладка окажется там, где YouTube не выдаёт новые cookies.",
+  "cookies.copyHint": "нажмите, чтобы скопировать",
+  "cookies.copied": "скопировано, вставьте туда",
+  "cookies.step4": "нажмите на значок расширения и выберите",
+  "cookies.step4export": "export",
+  "cookies.step4note":
+    "он рядом с адресной строкой, иногда под значком пазла. сохранит .txt в папку загрузок.",
+  "cookies.step5": "закройте эту вкладку YouTube",
+  "cookies.step5note":
+    "YouTube обновляет cookies в открытых вкладках, и каждое обновление старит ваш экспорт. именно закрытая вкладка продлевает им жизнь.",
+  "cookies.step6": "импортируйте этот файл здесь",
+
+  "cookies.importing": "импортируем…",
+  "cookies.replace": "заменить…",
+  "cookies.tryAgain": "ещё раз…",
+  "cookies.import": "импортировать cookies…",
+  "cookies.testing": "проверяем…",
+  "cookies.test": "проверить",
+  "cookies.remove": "удалить",
+
+  "cookies.footerSignedIn":
+    "YouTube со временем их меняет. когда это случится, cliply скажет об этом прямо здесь.",
+  "cookies.footer":
+    "ничего отсюда никуда не отправляется. файл уходит только в YouTube и только с вашего компьютера.",
+
+  "cookies.imported": "cookies импортированы",
+  "cookies.importedDesc": "теперь YouTube будет считать, что вы вошли.",
+  "cookies.notSignedIn": "импортировано, но вход не выполнен",
+  "cookies.notSignedInDesc": "с этими cookies вход не выполняется.",
+  "cookies.importFailed": "не удалось импортировать этот файл",
+  "cookies.importFailedDesc": "не удалось импортировать cookies",
+  "cookies.turnedDown": "YouTube их не принял",
+  "cookies.lookFine": "с cookies всё в порядке",
+  "cookies.notUsable": "cookies не подходят",
+  "cookies.testFailed": "не удалось проверить cookies",
+  "cookies.removeFailed": "не удалось удалить cookies",
+  "cookies.removeFailedDesc": "они всё ещё на этом компьютере.",
+  "cookies.copyFailed": "не удалось скопировать",
+  "cookies.copyFailedDesc":
+    "введите youtube.com/robots.txt в этой вкладке вручную.",
+
+  "toast.overwhelmed": "мы перегружены",
+  "toast.openFolder": "открыть папку",
+  "toast.report": "сообщить",
+  "toast.fixWithCookies": "исправить через cookies",
+  "toast.botCookies": "обычно помогает вход через запасной аккаунт.",
+  "toast.botGeneric": "сайт просит подтвердить, что мы не боты.",
+  "toast.audioDone": "аудио скачано",
+  "toast.videoDone": "видео скачано",
+  "toast.audioDoneDesc": "аудиофайл сохранён на ваше устройство.",
+  "toast.videoDoneDesc": "видеофайл сохранён на ваше устройство.",
+
+  "download.startingAudio": "начинаем скачивание аудио...",
+  "download.startingVideo": "начинаем скачивание видео...",
+  "download.audioProgress": "скачиваем аудио... {percent}%",
+  "download.videoProgress": "скачиваем видео... {percent}%",
+  "download.audioCompleted": "аудио скачано",
+  "download.videoCompleted": "видео скачано",
+  "download.saved": "сохранено: {filename}",
+  "download.audioFailed": "не удалось скачать аудио",
+  "download.videoFailed": "не удалось скачать видео",
+  "download.failed": "не удалось скачать",
+  "download.wentWrong": "что-то пошло не так. вы можете отправить нам подробности.",
+  "download.startFailed": "не удалось начать скачивание: {message}",
+  "download.cancelled": "скачивание отменено",
+  "download.audioCancelled": "скачивание аудио отменено",
+  "download.videoCancelled": "скачивание видео отменено",
+  "download.complete": "скачивание завершено",
+  "download.video": "скачать видео",
+  "download.audio": "скачать аудио",
+  "download.inProgress": "скачивание...",
+  "download.mergeHint": "видео и аудио объединятся автоматически",
+  "download.audioHint": "аудио будет скачано в выбранном формате и диапазоне",
+
+  "card.tabVideo": "видео",
+  "card.tabAudio": "только аудио",
+  "card.videoIntro": "скачивание видео с подходящей аудиодорожкой",
+  "card.audioIntro": "извлечение аудио из видео в выбранном диапазоне",
+  "card.summary": "параметры загрузки",
+  "card.uploader": "автор:",
+  "card.duration": "длительность:",
+  "card.size": "размер:",
+  "card.format": "формат:",
+  "card.language": "язык:",
+  "card.timeRange": "диапазон:",
+  // the row sits beside a video icon and a "1080p MP4" value, so the noun the
+  // english label repeats is not needed to read it
+  "card.videoQuality": "качество:",
+  "card.audioTrack": "дорожка:",
+  "card.bestAvailable": "лучшая доступная",
+  "card.preciseCut": "точная обрезка:",
+  "card.enabled": "включено",
+  "card.disabled": "выключено",
+  "card.preciseCutHint":
+    "выключите для быстрой загрузки, но обрезка будет менее точной",
+  "card.pinterestSubtitle": "лучшее доступное качество, файл MP4.",
+  "card.tiktokSubtitle":
+    "лучшее доступное качество, файл MP4. без водяного знака.",
+
+  "dropdown.videoQuality": "качество видео",
+  "dropdown.videoQualityPlaceholder": "выберите качество...",
+  "dropdown.audioFormat": "формат аудио",
+  "dropdown.audioFormatPlaceholder": "выберите формат...",
+  "dropdown.audioLanguage": "язык дорожки",
+  "dropdown.audioLanguagePlaceholder": "выберите язык дорожки...",
+  "dropdown.selected": "выбрано:",
+  "dropdown.plusBestAudio": "+ лучшее аудио",
+  "dropdown.original": "оригинал",
+  "dropdown.noVideoStreams":
+    "по этой ссылке нет видео, только аудио. вкладка «только аудио» всё равно работает.",
+
+  "format.mp3": "MP3",
+  "format.m4a": "M4A",
+  "format.mp3Detail": "с конвертацией · играет везде",
+  "format.m4aDetail": "AAC · с конвертацией",
+  // "source quality" is what the row's own label already says, and the detail
+  // shares a line with it - so the russian drops it rather than wrap
+  "format.originalDetail": "без перекодирования · обычно WEBM/Opus",
+
+  "time.selection": "выбор диапазона",
+  "time.range": "диапазон времени",
+  "time.start": "начало",
+  "time.end": "конец",
+  "time.selectedDuration": "длительность:",
+  "time.helper": "формат MM:SS или HH:MM:SS. максимум: {max}",
+  "time.helperShort": "формат: MM:SS или HH:MM:SS • максимум: {max}",
+  "time.invalid": "неверный диапазон",
+  "time.startNegative": "начало не может быть отрицательным",
+  "time.endExceeds": "конец выходит за длительность видео",
+  "time.endBeforeStart": "конец должен быть позже начала",
+
+  "media.video": "видео",
+  "media.audio": "аудио",
+  "progress.downloading": "скачивание {label}",
+  "progress.processing": "обработка {label}",
+  "progress.startingUp": "запускаем",
+  "progress.trimming": "при обрезке прогресс не показывается",
+  "progress.stop": "стоп",
+  "progress.stopTitle": "остановить загрузку",
+  "progress.working": "идёт работа",
+
+  "feedback.title": "помогите улучшить",
+  "feedback.subtitle": "предложите функцию",
+  "feedback.cta": "жмите :)",
+
+  "layout.downloadsAt": "загрузки сохраняются в",
+  "layout.concurrentNote":
+    "можно качать несколько файлов сразу, скорость при этом может падать.",
+
+  "thumb.unavailable": "превью недоступно",
+  "thumb.viewOn": "открыть в {name}",
+  "thumb.openFailed": "не удалось открыть ссылку {name}",
+  "player.cantDisplay": "не удаётся показать видео",
+
+  "update.available": "доступно обновление",
+  "update.macManual": "версию {version} на Mac нужно скачать вручную",
+  "update.download": "скачать",
+  "update.downloadingTitle": "обновление скачивается",
+  "update.autoDownloading": "версия {version} скачивается в фоне автоматически",
+  "update.readyToDownload": "версия {version} готова к скачиванию",
+  "update.upToDate": "у вас последняя версия",
+  "update.upToDateDesc": "новее пока нет",
+  "update.progress": "скачиваем обновление: {percent}%",
+  "update.inBackground": "скачиваем в фоне...",
+  "update.readyToInstallToast": "обновление готово к установке",
+  "update.downloadedDesc":
+    "версия {version} скачана. она установится, когда вы закроете приложение.",
+  "update.installNow": "установить",
+  "update.checking": "проверяем обновления...",
+  "update.error": "ошибка обновления",
+  "update.preparing": "готовим скачивание...",
+  "update.preparingDesc": "запускаем скачивание обновления",
+  "update.started": "скачивание началось",
+  "update.startedDesc":
+    "обновление скачивается в фоне. приложением можно пользоваться дальше.",
+  "update.downloadFailed": "не удалось скачать",
+  "update.downloadFailedDesc": "не удалось скачать обновление",
+  "update.checkConnection": "попробуйте ещё раз или проверьте подключение",
+  "update.installing": "устанавливаем обновление",
+  "update.installingDesc":
+    "приложение закроется и откроется уже с новой версией",
+  "update.installFailed": "не удалось установить",
+  "update.installFailedDesc": "попробуйте скачать обновление ещё раз",
+
+  "update.cardDownloading": "скачиваем обновление",
+  "update.cardProgress": "версия {version} • скачано {percent}%",
+  "update.cardReady": "обновление готово",
+  "update.cardReadyDesc": "версия {version} готова к установке",
+  "update.installRestart": "установить и перезапустить",
+  "update.tryAgain": "попробовать ещё раз",
+  "update.importantUpdates": "проверить важные обновления",
+
+  "update.macDesc":
+    "на Mac мы не умеем обновляться сами. нажмите «почему», чтобы узнать больше.",
+  "update.newVersion": "доступна новая версия cliply.",
+  "update.version": "версия {version}",
+  "update.released": "вышла {date}",
+  "update.later": "позже",
+  "update.learnWhy": "почему",
+  "update.downloadFromGithub": "скачать с GitHub",
+  "update.downloadUpdate": "скачать обновление",
+  "update.readyToInstall": "обновление готово к установке",
+  "update.readyToInstallDesc":
+    "обновление скачано и готово к установке. приложение перезапустится само.",
+  "update.whenReady": "установим, когда вы будете готовы",
+
+  "report.title": "сообщить о проблеме",
+  "report.description":
+    "откроется заполненный черновик обращения на GitHub в вашем браузере. посмотрите его там и опубликуйте, когда будете готовы.",
+  "report.whatWentWrong": "что пошло не так",
+  "report.yourSetup": "ваша система, приложим как есть",
+  "report.technicalDetails": "технические детали, которые мы приложим",
+  "report.show": "показать",
+  "report.notes": "что вы делали, когда это случилось?",
+  "report.notesPlaceholder": "необязательно, но так мы найдём причину быстрее.",
+  // present tense keeps the line the same for everyone: "скачивал" would pick a
+  // gender the app has no way of knowing
+  "report.includeLink": "приложить ссылку, которую я скачиваю",
+  "report.notNow": "не сейчас",
+  "report.openOnGithub": "открыть на GitHub",
+  "report.opening": "открываем GitHub",
+  "report.trimmed":
+    "мы обрезали логи, чтобы всё поместилось. полный отчёт скопирован в буфер обмена.",
+  "report.reviewIt": "проверьте заполненное обращение и отправьте его.",
+  "report.browserFailed": "не удалось открыть браузер",
+  "report.browserFailedDesc":
+    "полный отчёт в буфере обмена. вставьте его на github.com/Cliply/Cliply/issues/new",
+
+  // english needs no plural here - main's milestones are all well past one -
+  // but russian picks a form for every number, so all three are spelled out
+  "support.title":
+    "это уже {n} загрузка|это уже {n} загрузки|это уже {n} загрузок",
+  "support.description":
+    "cliply бесплатный, без рекламы и без слежки. его делает и поддерживает один человек в свободное время, в основном вопреки тому, что YouTube нарочно всё меняет.",
+  "support.ask": "если он сэкономил вам время, кофе поможет.",
+  "support.decline": "нет, спасибо"
+}
+
+/**
+ * main's error wording, in russian, keyed by the taxonomy category it carries
+ *
+ * main stays english on purpose - its sentences feed logs, analytics and issue
+ * bodies that maintainers read - so the translation is an overlay here, applied
+ * only to the toast the user reads. one entry per key of `ERROR_METADATA` and
+ * `TERMINAL_ERRORS` in `src/main/services/ytdlp-engine.js`; a category with no
+ * entry keeps main's english, which is the right failure mode for a code this
+ * file has not caught up with yet.
+ */
+export const ruErrors: Partial<
+  Record<string, { message: string; suggestion: string }>
+> = {
+  BOT_DETECTION: {
+    message: "YouTube просит подтвердить, что вы не бот.",
+    suggestion: "импортируйте cookies YouTube в настройках и попробуйте снова."
+  },
+  VIDEO_UNAVAILABLE: {
+    message: "это видео недоступно для скачивания.",
+    suggestion: "возможно, оно приватное, с возрастным ограничением или удалено."
+  },
+  NOT_A_VIDEO: {
+    message: "по этой ссылке нет видео.",
+    suggestion: "cliply скачивает видео, попробуйте ссылку, где оно есть."
+  },
+  GEO_BLOCKED: {
+    message: "это видео недоступно в вашей стране.",
+    suggestion: "автор ограничил, где его можно смотреть."
+  },
+  EXTRACTION_FAILED: {
+    message: "YouTube что-то изменил, и загрузчику нужно это догнать.",
+    suggestion: "обычно помогает обновление загрузчика."
+  },
+  NETWORK_ERROR: {
+    message: "сеть прервала скачивание.",
+    suggestion: "проверьте подключение и попробуйте снова."
+  },
+  RATE_LIMITED: {
+    message: "YouTube временно ограничивает это устройство.",
+    suggestion: "подождите несколько минут перед следующей попыткой."
+  },
+  DISK_FULL: {
+    message: "на диске не хватает места для этой загрузки.",
+    suggestion: "освободите место и попробуйте снова."
+  },
+  PERMISSION_ERROR: {
+    message: "не получается записать в папку загрузок.",
+    suggestion: "проверьте права доступа или выберите другую папку."
+  },
+  PATH_ERROR: {
+    message: "не удалось записать по этому пути.",
+    suggestion: "выберите другую папку для загрузок или путь покороче."
+  },
+  JS_RUNTIME_MISSING: {
+    message: "не хватает компонента, который нужен загрузчику.",
+    suggestion: "переустановите cliply."
+  },
+  FFMPEG_MISSING: {
+    message: "видеообработчик отсутствует.",
+    suggestion: "переустановите cliply."
+  },
+  FFMPEG_AV_BLOCKED: {
+    message: "антивирус остановил видеообработчик.",
+    suggestion: "разрешите cliply в антивирусе и попробуйте снова."
+  },
+  FFMPEG_CORRUPT_STREAM: {
+    message: "видеопоток оказался повреждён.",
+    suggestion: "попробуйте другое качество."
+  },
+  FFMPEG_ERROR: {
+    message: "что-то пошло не так при обработке видео.",
+    suggestion: "попробуйте ещё раз."
+  },
+  CANCELLED: {
+    message: "скачивание отменено.",
+    suggestion: "начните его заново, когда будете готовы."
+  },
+  STALLED: {
+    message: "скачивание перестало отвечать.",
+    suggestion: "проверьте подключение и попробуйте снова."
+  },
+  ENGINE_MISSING: {
+    message: "движок загрузчика отсутствует.",
+    suggestion: "перезапустите cliply, а если это повторяется, переустановите его."
+  },
+  DOWNLOAD_FAILED: {
+    message: "не удалось скачать.",
+    suggestion: "попробуйте ещё раз."
+  }
+}
+
+/**
+ * main's cookie sentences, in russian, keyed by the stable code beside them
+ *
+ * the same overlay as `ruErrors`, for the three places main words a cookie
+ * verdict: the import refusals thrown by `cookie-manager.js`, the jar problems
+ * (`JAR_*`) and the probe notes (`PROBE_*`) composed in `ipc-handlers.js`.
+ *
+ * two of main's notes interpolate a value - the probe's own error text, and how
+ * many test videos were down - and the code arrives without it. Both say
+ * nothing a russian reader can act on, so the translation drops them rather
+ * than widening the ipc payload to carry them across.
+ */
+export const ruCodes: Partial<Record<string, string>> = {
+  COOKIES_FILE_EMPTY: "этот файл пустой.",
+  COOKIES_MALFORMED:
+    "этот файл с cookies испорчен. колонка домена расходится с собственным флагом поддомена, поэтому yt-dlp отвергает его целиком. сделайте свежий экспорт вместо правки вручную.",
+  COOKIES_EMPTY:
+    "в этом файле нет cookies. экспортируйте cookies.txt расширением и выберите именно его.",
+  COOKIES_NOT_YOUTUBE:
+    "в файле есть cookies, но ни одного от YouTube. экспортируйте cookies.txt, находясь на youtube.com.",
+  COOKIES_TOO_BIG:
+    "этот файл слишком большой для экспорта cookies. выберите cookies.txt, который сохранило расширение.",
+  COOKIES_JSON:
+    "это json, а не cookies.txt в формате netscape. экспортируйте именно cookies.txt.",
+
+  JAR_MALFORMED: "файл испорчен, сделайте свежий экспорт вместо правки вручную",
+  JAR_NOT_COOKIE_FILE: "это не файл cookies.txt, экспортируйте его заново",
+  JAR_NOTHING_IMPORTED: "пока ничего не импортировано",
+  JAR_NO_YOUTUBE: "в файле нет cookies от YouTube",
+  JAR_EXPIRED: "ваши cookies истекли, сделайте свежий экспорт",
+  JAR_SESSION_ENDED: "YouTube завершил эту сессию, экспортируйте cookies заново",
+  JAR_NEVER_SIGNED_IN:
+    "эти cookies не из сессии со входом, сначала войдите, потом экспортируйте",
+  JAR_UNUSABLE: "нет пригодных cookies от YouTube",
+
+  PROBE_PASSED:
+    "скачивание сработало с вашими cookies. само по себе это не доказывает, что YouTube их принял.",
+  PROBE_EMPTY: "тестовое видео вернулось пустым.",
+  PROBE_REJECTED:
+    "YouTube всё равно просит подтвердить, что мы не боты, хотя ваши cookies отправлены, значит они истекли или не принимаются.",
+  PROBE_UNREACHABLE:
+    "не удалось связаться с YouTube, поэтому cookies остались непроверенными.",
+  PROBE_FAILED: "тест не удалось завершить.",
+  PROBE_TARGETS_DOWN:
+    "все наши тестовые видео сейчас недоступны, так что это ничего не говорит о ваших cookies."
+}

--- a/src/main/renderer/src/lib/platform-config.ts
+++ b/src/main/renderer/src/lib/platform-config.ts
@@ -2,6 +2,7 @@ import { zodResolver } from "@hookform/resolvers/zod"
 import type { Resolver } from "react-hook-form"
 
 import { pinterestApi, tiktokApi, videoApi } from "@/lib/api"
+import type { Key } from "@/lib/i18n"
 import { usePinterestStore } from "@/lib/pinterestStore"
 import type { Platform } from "@/lib/store"
 import { useTikTokStore } from "@/lib/tiktokStore"
@@ -30,20 +31,27 @@ export interface MediaSummary {
   formatsCount: number | null
 }
 
+/**
+ * every user-facing field here is a translation key, not a sentence: the
+ * registry is built once at module load, so a string baked in here would stay
+ * in whichever language was current when the app started. the consumers call
+ * `t()` at render time instead. `logPrefix` is the exception - it only ever
+ * reaches the console.
+ */
 export interface PlatformConfig {
   id: Platform
   label: string
   logo: string
   formResolver: Resolver<{ url: string }>
-  placeholder: string
-  helperText: string
-  loadingText: string
-  successMessage: string
+  placeholder: Key
+  helperText: Key
+  loadingText: Key
+  successMessage: Key
   errorMessages: {
-    invalidUrl: string
-    invalidUrlToast: string
-    unavailable: string
-    genericFail: string
+    invalidUrl: Key
+    invalidUrlToast: Key
+    unavailable: Key
+    genericFail: Key
     logPrefix: string
   }
   fetchAndStore: (url: string) => Promise<MediaSummary>
@@ -56,16 +64,15 @@ export const PLATFORM_REGISTRY: Record<Platform, PlatformConfig> = {
     label: "youtube",
     logo: "./youtube-logo.svg",
     formResolver: zodResolver(youtubeUrlSchema),
-    placeholder: "paste video url here...",
-    helperText:
-      "supports youtube videos & shorts from youtube.com and youtu.be",
-    loadingText: "\u{1F40B} getting video information",
-    successMessage: "Video information loaded successfully!",
+    placeholder: "url.placeholder",
+    helperText: "url.youtubeHelper",
+    loadingText: "url.loading",
+    successMessage: "url.loaded",
     errorMessages: {
-      invalidUrl: "Invalid YouTube URL",
-      invalidUrlToast: "Please enter a valid YouTube URL",
-      unavailable: "This video is not available for download",
-      genericFail: "Failed to get video information",
+      invalidUrl: "error.youtubeUrl",
+      invalidUrlToast: "validation.youtubeInvalid",
+      unavailable: "error.unavailable",
+      genericFail: "error.infoFailed",
       logPrefix: "Video info request failed:"
     },
     fetchAndStore: async (url: string) => {
@@ -92,15 +99,15 @@ export const PLATFORM_REGISTRY: Record<Platform, PlatformConfig> = {
     label: "pinterest",
     logo: "./pinterest-logo.svg",
     formResolver: zodResolver(pinterestUrlSchema),
-    placeholder: "paste video url here...",
-    helperText: "supports pin.it and pinterest.com/pin links, any country domain",
-    loadingText: "\u{1F40B} getting video information",
-    successMessage: "Video information loaded successfully!",
+    placeholder: "url.placeholder",
+    helperText: "url.pinterestHelper",
+    loadingText: "url.loading",
+    successMessage: "url.loaded",
     errorMessages: {
-      invalidUrl: "Invalid Pinterest URL",
-      invalidUrlToast: "Please enter a valid Pinterest URL",
-      unavailable: "This video is not available for download",
-      genericFail: "Failed to get video information",
+      invalidUrl: "error.pinterestUrl",
+      invalidUrlToast: "validation.pinterestInvalid",
+      unavailable: "error.unavailable",
+      genericFail: "error.infoFailed",
       logPrefix: "Pinterest info request failed:"
     },
     fetchAndStore: async (url: string) => {
@@ -124,15 +131,15 @@ export const PLATFORM_REGISTRY: Record<Platform, PlatformConfig> = {
     label: "tiktok",
     logo: "./tiktok-logo.svg",
     formResolver: zodResolver(tiktokUrlSchema),
-    placeholder: "paste video url here...",
-    helperText: "supports tiktok.com/@user/video/ID, vm.tiktok.com, and vt.tiktok.com links",
-    loadingText: "\u{1F40B} getting video information",
-    successMessage: "Video information loaded successfully!",
+    placeholder: "url.placeholder",
+    helperText: "url.tiktokHelper",
+    loadingText: "url.loading",
+    successMessage: "url.loaded",
     errorMessages: {
-      invalidUrl: "Invalid TikTok URL",
-      invalidUrlToast: "Please enter a valid TikTok URL",
-      unavailable: "This video is not available for download",
-      genericFail: "TikTok blocked this request — please try again in a moment",
+      invalidUrl: "error.tiktokUrl",
+      invalidUrlToast: "validation.tiktokInvalid",
+      unavailable: "error.unavailable",
+      genericFail: "error.tiktokBlocked",
       logPrefix: "TikTok info request failed:"
     },
     fetchAndStore: async (url: string) => {

--- a/src/main/renderer/src/lib/toast-utils.test.tsx
+++ b/src/main/renderer/src/lib/toast-utils.test.tsx
@@ -14,6 +14,7 @@ const openReport = vi.fn()
 vi.mock("@/lib/cookieStore", () => ({ cookieActions: { open: () => openCookies() } }))
 vi.mock("@/lib/reportStore", () => ({ reportActions: { open: () => openReport() } }))
 
+import { useLocale } from "@/lib/i18n"
 import { showBotDetectionToast, showDownloadErrorToast } from "@/lib/toast-utils"
 
 function actionOf(call: number = 0) {
@@ -27,6 +28,7 @@ beforeEach(() => {
   toastError.mockClear()
   openCookies.mockClear()
   openReport.mockClear()
+  useLocale.setState({ locale: "en" })
 })
 
 describe("showDownloadErrorToast", () => {
@@ -111,4 +113,23 @@ describe("showBotDetectionToast", () => {
       expect(openCookies).not.toHaveBeenCalled()
     }
   )
+
+  /**
+   * the toast a blocked russian user reads, which is the walk this whole
+   * translation exists for. The title is main's own sentence, localized at the
+   * call site before it reaches here; the description and the way out are ours.
+   */
+  test("speaks russian, and still offers the cookie door", () => {
+    useLocale.setState({ locale: "ru" })
+
+    showBotDetectionToast("YouTube просит подтвердить, что вы не бот.", "youtube")
+
+    expect(toastError.mock.calls[0][1].description).toBe(
+      "обычно помогает вход через запасной аккаунт."
+    )
+    expect(actionOf().label).toBe("исправить через cookies")
+
+    actionOf().onClick()
+    expect(openCookies).toHaveBeenCalled()
+  })
 })

--- a/src/main/renderer/src/lib/toast-utils.tsx
+++ b/src/main/renderer/src/lib/toast-utils.tsx
@@ -1,5 +1,6 @@
 import { toast } from "sonner"
 import { cookieActions } from "@/lib/cookieStore"
+import { t } from "@/lib/i18n"
 import { reportActions } from "@/lib/reportStore"
 import type { Platform } from "@/lib/store"
 
@@ -7,26 +8,25 @@ export const showServerOverwhelmedToast = () => {
   toast(
     <div className="flex items-center gap-3 font-space-grotesk">
       <span className="text-lg">🌻</span>
-      <span>we&apos;re overwhelmed</span>
+      <span>{t("toast.overwhelmed")}</span>
     </div>
   )
 }
 
 export const showDownloadSuccessToast = (type: "audio" | "video") => {
-  toast.success(
-    `${type === "audio" ? "Audio" : "Video"} downloaded successfully!`,
-    {
-      description: `Your ${type} file has been downloaded to your device.`,
-      action: {
-        label: "Open Folder",
-        onClick: () => window.electronAPI?.system?.openDownloadFolder?.()
-      }
+  const audio = type === "audio"
+
+  toast.success(t(audio ? "toast.audioDone" : "toast.videoDone"), {
+    description: t(audio ? "toast.audioDoneDesc" : "toast.videoDoneDesc"),
+    action: {
+      label: t("toast.openFolder"),
+      onClick: () => window.electronAPI?.system?.openDownloadFolder?.()
     }
-  )
+  })
 }
 
 export const showFolderSelectedToast = () => {
-  toast.success("Download folder updated!")
+  toast.success(t("folder.updated"))
 }
 
 /**
@@ -55,12 +55,12 @@ export const showBotDetectionToast = (message: string, platform?: Platform) => {
   toast.error(message, {
     id: "bot-detected",
     description: cookiesCanHelp(platform)
-      ? "signing in with a throwaway account usually clears this."
-      : "this site wants us to prove we're not a bot.",
+      ? t("toast.botCookies")
+      : t("toast.botGeneric"),
     duration: 12000,
     action: cookiesCanHelp(platform)
-      ? { label: "fix with cookies", onClick: () => cookieActions.open() }
-      : { label: "report", onClick: () => reportActions.open() }
+      ? { label: t("toast.fixWithCookies"), onClick: () => cookieActions.open() }
+      : { label: t("toast.report"), onClick: () => reportActions.open() }
   })
 }
 
@@ -92,7 +92,7 @@ export const showDownloadErrorToast = (
     description,
     duration: 12000,
     action: blocked
-      ? { label: "fix with cookies", onClick: () => cookieActions.open() }
-      : { label: "report", onClick: () => reportActions.open() }
+      ? { label: t("toast.fixWithCookies"), onClick: () => cookieActions.open() }
+      : { label: t("toast.report"), onClick: () => reportActions.open() }
   })
 }

--- a/src/main/renderer/src/lib/validation.ts
+++ b/src/main/renderer/src/lib/validation.ts
@@ -1,5 +1,13 @@
 import { z } from "zod"
 
+import type { Key } from "@/lib/i18n"
+
+/**
+ * zod bakes a message into the schema when the schema is built, which is once,
+ * at module load. so the message a schema carries is a translation key, and
+ * whoever renders or toasts it calls `t()` on it then.
+ */
+
 const YOUTUBE_URL_REGEX = /^(https?:\/\/)?(www\.)?(youtube\.com\/(watch\?v=|embed\/|v\/|shorts\/)|youtu\.be\/)[\w-]+/
 /**
  * pinterest sends people to their own country's domain, so `www.pinterest.com`
@@ -22,8 +30,11 @@ const TIKTOK_URL_REGEX = /^https?:\/\/(?:(?:www\.)?tiktok\.com\/@[\w.-]+\/video\
 export const youtubeUrlSchema = z.object({
   url: z
     .string()
-    .min(1, "Please enter a YouTube URL")
-    .refine((url: string) => YOUTUBE_URL_REGEX.test(url), "Please enter a valid YouTube URL")
+    .min(1, "validation.youtubeRequired" satisfies Key)
+    .refine(
+      (url: string) => YOUTUBE_URL_REGEX.test(url),
+      "validation.youtubeInvalid" satisfies Key
+    )
 })
 
 export type YouTubeUrlFormData = z.infer<typeof youtubeUrlSchema>
@@ -35,10 +46,10 @@ export const isValidYouTubeUrl = (url: string): boolean => {
 export const pinterestUrlSchema = z.object({
   url: z
     .string()
-    .min(1, "Please enter a Pinterest URL")
+    .min(1, "validation.pinterestRequired" satisfies Key)
     .refine(
       (url: string) => PINTEREST_URL_REGEX.test(url),
-      "Please enter a valid Pinterest URL"
+      "validation.pinterestInvalid" satisfies Key
     )
 })
 
@@ -51,10 +62,10 @@ export const isValidPinterestUrl = (url: string): boolean => {
 export const tiktokUrlSchema = z.object({
   url: z
     .string()
-    .min(1, "Please enter a TikTok URL")
+    .min(1, "validation.tiktokRequired" satisfies Key)
     .refine(
       (url: string) => TIKTOK_URL_REGEX.test(url),
-      "Please enter a valid TikTok URL"
+      "validation.tiktokInvalid" satisfies Key
     )
 })
 

--- a/src/main/services/cookie-manager.js
+++ b/src/main/services/cookie-manager.js
@@ -88,6 +88,20 @@ function looksLikeJson(content) {
   return first === "[" || first === "{" || first === '"'
 }
 
+/**
+ * a refusal the renderer can say in the user's own language
+ *
+ * the sentence stays english - it is what the logs, the issue bodies and the
+ * maintainers read - and a stable code travels beside it, so the ui translates
+ * by code rather than by matching english prose that is free to be reworded.
+ *
+ * the codes: COOKIES_FILE_EMPTY, COOKIES_MALFORMED, COOKIES_EMPTY,
+ * COOKIES_NOT_YOUTUBE, COOKIES_TOO_BIG, COOKIES_JSON.
+ */
+function refuse(code, message) {
+  return Object.assign(new Error(message), { code })
+}
+
 // written by older builds; it claimed the cookies worked when all it knew was
 // that the file existed, so it is stripped wherever status is read or written
 const LEGACY_STATUS_KEYS = ["working"]
@@ -225,7 +239,7 @@ class CookieManager {
    */
   async importCookies(cookieContent) {
     if (!cookieContent || !cookieContent.trim()) {
-      throw new Error("that file is empty.")
+      throw refuse("COOKIES_FILE_EMPTY", "that file is empty.")
     }
 
     // into yt-dlp's own shape: its line endings, and its magic first line
@@ -247,19 +261,22 @@ class CookieManager {
     const { error, cookies } = readJar(content)
 
     if (error === JAR_DOMAIN_FLAG) {
-      throw new Error(
+      throw refuse(
+        "COOKIES_MALFORMED",
         "that cookie file is malformed. a domain column disagrees with its own subdomain flag, so yt-dlp refuses the whole thing. export a fresh one instead of editing it by hand."
       )
     }
 
     if (cookies.length === 0) {
-      throw new Error(
+      throw refuse(
+        "COOKIES_EMPTY",
         "there are no cookies in that file. export cookies.txt with the extension, then pick that one."
       )
     }
 
     if (!cookies.some((cookie) => isYouTubeDomain(cookie.domain))) {
-      throw new Error(
+      throw refuse(
+        "COOKIES_NOT_YOUTUBE",
         "that file has cookies, but none of them are youtube's. export cookies.txt while you're on youtube.com."
       )
     }
@@ -293,7 +310,8 @@ class CookieManager {
       const { size } = await fs.stat(filePath)
 
       if (size > MAX_JAR_BYTES) {
-        throw new Error(
+        throw refuse(
+          "COOKIES_TOO_BIG",
           "that file is way too big to be a cookie export. pick the cookies.txt the extension saved."
         )
       }
@@ -317,7 +335,8 @@ class CookieManager {
        * says exactly this, so we say the same thing.
        */
       if (looksLikeJson(content)) {
-        throw new Error(
+        throw refuse(
+          "COOKIES_JSON",
           "that's json, not a netscape cookies.txt. export it as cookies.txt instead."
         )
       }

--- a/tests/app-lifecycle.test.js
+++ b/tests/app-lifecycle.test.js
@@ -306,6 +306,46 @@ describe("initialize", () => {
 
     jest.restoreAllMocks()
   })
+
+  it("does not build the menu before the app is ready", async () => {
+    // the labels come from app.getLocale(), which answers with an empty string
+    // until ready - and services finishing first is only a matter of how fast
+    // the machine is
+    let markReady
+    mockElectron.app.whenReady.mockReturnValueOnce(
+      new Promise((resolve) => {
+        markReady = resolve
+      })
+    )
+
+    jest
+      .spyOn(CliplyApp.prototype, "initializeServices")
+      .mockImplementation(async () => {})
+    jest
+      .spyOn(CliplyApp.prototype, "setupAppEvents")
+      .mockImplementation(() => {})
+    const menu = jest
+      .spyOn(CliplyApp.prototype, "createMenu")
+      .mockImplementation(() => {})
+    jest
+      .spyOn(CliplyApp.prototype, "setupAutoUpdater")
+      .mockImplementation(() => {})
+    jest
+      .spyOn(CliplyApp.prototype, "checkSupportedArchitecture")
+      .mockImplementation(() => {})
+
+    const initialized = new CliplyApp().initialize()
+    await settle()
+
+    expect(menu).not.toHaveBeenCalled()
+
+    markReady()
+    await initialized
+
+    expect(menu).toHaveBeenCalledTimes(1)
+
+    jest.restoreAllMocks()
+  })
 })
 
 describe("the youtube embed referer", () => {
@@ -1040,6 +1080,62 @@ describe("the analytics opt-out menu item", () => {
       expect(menuItem.checked).toBe(true)
       expect(mockElectron.dialog.showMessageBox).not.toHaveBeenCalled()
     })
+  })
+})
+
+describe("the menu's language", () => {
+  // the whole menu bar, top level only - which is where the app menu darwin
+  // unshifts in front of File also shows up
+  const menuBar = () =>
+    mockElectron.Menu.buildFromTemplate.mock.calls
+      .at(-1)[0]
+      .map((entry) => entry.label)
+
+  it("follows the OS rather than the in-app toggle", () => {
+    // the menu bar belongs to the system, and it is built before a renderer
+    // exists to ask what the in-app language toggle is set to
+    mockElectron.app.getLocale.mockReturnValueOnce("ru-RU")
+    app.createMenu()
+
+    expect(menuBar()).toContain("Файл")
+  })
+
+  it("stays english for everyone else", () => {
+    app.createMenu()
+
+    expect(menuBar()).toContain("File")
+  })
+
+  // a russian menu item that puts up an english box is the worst of both, so
+  // the boxes these items raise come from the same table as their labels
+  it("speaks russian in the boxes its own items put up", async () => {
+    mockElectron.app.getLocale.mockReturnValueOnce("ru-RU")
+    app.createMenu()
+
+    // no ipc handlers is the "this build cannot check for updates" path
+    app.ipcHandlers = null
+    await mockElectron.Menu.buildFromTemplate.mock.calls
+      .at(-1)[0]
+      .find((entry) => entry.label === "Инструменты")
+      .submenu.find((entry) => entry.label === "Проверить обновления")
+      .click()
+
+    const [, options] = mockElectron.dialog.showMessageBox.mock.calls[0]
+    expect(options.title).toBe("Проверка обновлений недоступна")
+  })
+
+  it("falls back to english rather than letting a locale it cannot read stop it", () => {
+    // the menu is the whole menu bar, so a getLocale that throws has to cost
+    // the labels their translation and nothing more
+    mockElectron.app.getLocale.mockImplementationOnce(() => {
+      throw new Error("locale unavailable")
+    })
+    const error = jest.spyOn(console, "error").mockImplementation(() => {})
+
+    expect(() => app.createMenu()).not.toThrow()
+    expect(menuBar()).toContain("File")
+
+    error.mockRestore()
   })
 })
 

--- a/tests/cookie-ipc.test.js
+++ b/tests/cookie-ipc.test.js
@@ -163,3 +163,156 @@ describe("a cookie test that youtube rejected", () => {
     expect(response.data.rejected).toBe(false)
   })
 })
+
+/**
+ * the codes have to survive the trip, or the renderer is back to matching
+ * english prose to work out what main just said
+ *
+ * main stays english on purpose - its sentences feed the logs and the issue
+ * bodies - so a russian install says the same thing by looking the code up.
+ * A code that main computes and then drops at the ipc boundary is a code the
+ * dialog can never use.
+ */
+describe("the codes reach the renderer beside the sentences", () => {
+  test("a refused import carries the code it was refused under", async () => {
+    dialog.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: [path.join("/tmp", "picked.txt")]
+    })
+
+    const refusal = Object.assign(
+      new Error("that's json, not a netscape cookies.txt. export it as cookies.txt instead."),
+      { code: "COOKIES_JSON" }
+    )
+
+    const handlers = handlersWith({
+      importCookieFile: jest.fn().mockRejectedValue(refusal),
+      hasValidCookies: jest.fn(() => false),
+      hasYouTubeCookies: jest.fn(() => false)
+    })
+
+    const response = await handlers.handleImportCookieFile(null)
+
+    expect(response.error.code).toBe("COOKIES_JSON")
+    // and the english is still the message, which is the field the ui throws
+    expect(response.error.message).toMatch(/json, not a netscape/)
+  })
+
+  // a failure with no code of its own - a full disk, a permission error - must
+  // still come back, just without one to translate by
+  test("a failure main has no code for keeps the placeholder", async () => {
+    dialog.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: [path.join("/tmp", "picked.txt")]
+    })
+
+    const handlers = handlersWith({
+      importCookieFile: jest
+        .fn()
+        .mockRejectedValue(new Error("ENOSPC: no space left on device")),
+      hasValidCookies: jest.fn(() => false),
+      hasYouTubeCookies: jest.fn(() => false)
+    })
+
+    const response = await handlers.handleImportCookieFile(null)
+
+    expect(response.error.code).toBe("GENERAL_ERROR")
+  })
+
+  test("the status reports a problem as both a sentence and a code", async () => {
+    const handlers = handlersWith({
+      getStatus: jest.fn().mockResolvedValue({}),
+      getFileInfo: jest.fn().mockResolvedValue({
+        cookieCount: 12,
+        youtubeCookieCount: 12,
+        expiredCookieCount: 0,
+        hasSid: true,
+        signedIn: false,
+        loadError: null
+      }),
+      hasValidCookies: jest.fn(() => false),
+      hasYouTubeCookies: jest.fn(() => true)
+    })
+
+    const response = await handlers.handleGetCookieStatus(null)
+
+    expect(response.data.problemCode).toBe("JAR_SESSION_ENDED")
+    expect(response.data.problem).toBe(
+      "youtube ended this session, export your cookies again"
+    )
+  })
+
+  // a working jar has neither, and the code must not outlive the sentence
+  test("a jar that works reports no problem at all", async () => {
+    const handlers = handlersWith({
+      getStatus: jest.fn().mockResolvedValue({}),
+      getFileInfo: jest.fn().mockResolvedValue({
+        cookieCount: 22,
+        youtubeCookieCount: 22,
+        expiredCookieCount: 0,
+        hasSid: true,
+        signedIn: true,
+        loadError: null
+      }),
+      hasValidCookies: jest.fn(() => true),
+      hasYouTubeCookies: jest.fn(() => true)
+    })
+
+    const response = await handlers.handleGetCookieStatus(null)
+
+    expect(response.data.problem).toBeNull()
+    expect(response.data.problemCode).toBeNull()
+  })
+
+  test("a jar too broken to test reports the code with its note", async () => {
+    const handlers = handlersWith({
+      inspectCookieFile: jest.fn().mockResolvedValue({
+        total: 0,
+        youtube: 0,
+        expired: 0,
+        hasSid: false,
+        signedIn: false,
+        usable: false,
+        loadError: "domain-flag-mismatch"
+      }),
+      getStatus: jest.fn().mockResolvedValue({}),
+      updateStatus: jest.fn().mockResolvedValue(undefined),
+      hasValidCookies: jest.fn(() => false),
+      hasYouTubeCookies: jest.fn(() => false)
+    })
+
+    const response = await handlers.handleTestCookies(null)
+
+    expect(response.data.noteCode).toBe("JAR_MALFORMED")
+    expect(response.data.note).toMatch(/malformed/)
+  })
+
+  test("and a probe's verdict carries its own code across", async () => {
+    const handlers = handlersWith({
+      inspectCookieFile: jest.fn().mockResolvedValue({
+        total: 2,
+        youtube: 2,
+        expired: 0,
+        hasSid: true,
+        signedIn: true,
+        usable: true,
+        loadError: null
+      }),
+      getCookieFilePath: jest.fn(() => "/tmp/jar.txt"),
+      getStatus: jest.fn().mockResolvedValue({}),
+      updateStatus: jest.fn().mockResolvedValue(undefined),
+      hasValidCookies: jest.fn(() => true),
+      hasYouTubeCookies: jest.fn(() => true)
+    })
+
+    handlers.probeCookies = jest.fn().mockResolvedValue({
+      extractionCheck: "rejected",
+      noteCode: "PROBE_REJECTED",
+      note: "youtube still asked us to prove we're not a bot while sending your cookies."
+    })
+
+    const response = await handlers.handleTestCookies(null)
+
+    expect(response.data.noteCode).toBe("PROBE_REJECTED")
+  })
+})

--- a/tests/cookie-ipc.test.js
+++ b/tests/cookie-ipc.test.js
@@ -219,6 +219,30 @@ describe("the codes reach the renderer beside the sentences", () => {
     expect(response.error.code).toBe("GENERAL_ERROR")
   })
 
+  // node puts its own code on filesystem errors. that is not a refusal and
+  // must not cross as one, or the field means two things
+  test("a node error code is not forwarded as a refusal code", async () => {
+    dialog.showOpenDialog.mockResolvedValue({
+      canceled: false,
+      filePaths: [path.join("/tmp", "picked.txt")]
+    })
+
+    const full = Object.assign(new Error("ENOSPC: no space left on device"), {
+      code: "ENOSPC"
+    })
+
+    const handlers = handlersWith({
+      importCookieFile: jest.fn().mockRejectedValue(full),
+      hasValidCookies: jest.fn(() => false),
+      hasYouTubeCookies: jest.fn(() => false)
+    })
+
+    const response = await handlers.handleImportCookieFile(null)
+
+    expect(response.error.code).toBe("GENERAL_ERROR")
+    expect(response.error.message).toMatch(/no space left/)
+  })
+
   test("the status reports a problem as both a sentence and a code", async () => {
     const handlers = handlersWith({
       getStatus: jest.fn().mockResolvedValue({}),

--- a/tests/cookie-jar-problem.test.js
+++ b/tests/cookie-jar-problem.test.js
@@ -79,3 +79,46 @@ test("a jar with nothing expired in it is not called expired", () => {
     /aren't from a signed-in session/
   )
 })
+
+/**
+ * the same verdict as a code, which is what actually crosses to the renderer
+ *
+ * the sentence above is english and stays english. A russian install says the
+ * same thing by looking the code up, so a reworded sentence must never change
+ * one of these - which is exactly what this pins.
+ */
+describe("the code beside the sentence", () => {
+  const { cookieJarProblemCode } = require("../src/main/ipc-handlers")
+  const { JAR_DOMAIN_FLAG, JAR_UNREADABLE } = require("../src/main/utils/cookie-jar")
+
+  test.each([
+    [jar({ total: 0, youtube: 0, loadError: JAR_DOMAIN_FLAG }), "JAR_MALFORMED"],
+    [jar({ total: 0, youtube: 0, loadError: JAR_UNREADABLE }), "JAR_NOT_COOKIE_FILE"],
+    [jar({ total: 0, youtube: 0 }), "JAR_NOTHING_IMPORTED"],
+    [jar({ youtube: 0 }), "JAR_NO_YOUTUBE"],
+    [jar({ expired: 12 }), "JAR_EXPIRED"],
+    [jar({ hasSid: true }), "JAR_SESSION_ENDED"],
+    [jar({ hasSid: false }), "JAR_NEVER_SIGNED_IN"],
+    [jar({ signedIn: true }), "JAR_UNUSABLE"]
+  ])("%o is %s", (inspection, code) => {
+    expect(cookieJarProblemCode(inspection)).toBe(code)
+  })
+
+  // and the two answers never disagree: every code has a sentence
+  test("every code the function can return has wording", () => {
+    const inspections = [
+      jar({ total: 0, youtube: 0, loadError: JAR_DOMAIN_FLAG }),
+      jar({ total: 0, youtube: 0, loadError: JAR_UNREADABLE }),
+      jar({ total: 0, youtube: 0 }),
+      jar({ youtube: 0 }),
+      jar({ expired: 12 }),
+      jar({ hasSid: true }),
+      jar({ hasSid: false }),
+      jar({ signedIn: true })
+    ]
+
+    for (const inspection of inspections) {
+      expect(typeof cookieJarProblem(inspection)).toBe("string")
+    }
+  })
+})

--- a/tests/cookie-manager.test.js
+++ b/tests/cookie-manager.test.js
@@ -38,18 +38,34 @@ function loginPair(expires, domain = ".youtube.com") {
 const HOUR = 3600
 const nowSeconds = () => Math.floor(Date.now() / 1000)
 
+/**
+ * the constructor fires initialize() and does not await it, so every manager
+ * these tests build leaves one running against paths the next two lines are
+ * about to move. that stray run ends with
+ * `this.isValid = await this.validateCookieFile()`, and there is a window where
+ * it reads the jar before a test overwrites it and assigns after - inside the
+ * updateStatus await in importCookies, between that method's own validate and
+ * its `return this.isValid`. the test then reads a verdict about the previous
+ * file. it only loses the race under a full parallel run, which is exactly when
+ * it was seen.
+ *
+ * nothing here wants that initialize: managerWith writes every fixture itself,
+ * and the two tests that want its steps call ensureCookieFile() directly. so it
+ * is stubbed out for this suite - which also stops each construction from
+ * mkdir-ing the real APP_CONFIG.COOKIES_DIR on the machine running the tests.
+ */
+beforeEach(() => {
+  jest.spyOn(CookieManager.prototype, "initialize").mockResolvedValue(undefined)
+})
+
 async function managerWith(content) {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "cliply-cookies-"))
   const cookieFile = path.join(dir, "youtube_cookies.txt")
 
-  // write the fixture first: the constructor kicks off initialize(), which
-  // creates an empty cookie file when it finds none, and would otherwise race
-  // this write and clobber it
   await fs.writeFile(cookieFile, content, "utf8")
 
   const manager = new CookieManager()
 
-  // reassigned synchronously, before initialize() gets past its first await
   manager.cookieDir = dir
   manager.cookieFile = cookieFile
   manager.statusFile = path.join(dir, "cookie_status.json")
@@ -602,5 +618,83 @@ describe("clearing", () => {
     expect(await manager.validateCookieFile()).toBe(true)
 
     write.mockRestore()
+  })
+})
+
+/**
+ * every refusal carries a code as well as a sentence
+ *
+ * the sentence stays english, because it is what the logs, the issue bodies and
+ * the maintainers read. The renderer has to say the same thing in the user's
+ * language, and matching english prose to work out which refusal it is holding
+ * would break the first time anyone reworded one. So the code is the contract,
+ * and these are the six of it.
+ */
+describe("the code beside the refusal", () => {
+  const live = () => String(nowSeconds() + HOUR)
+
+  const codeOf = async (importing) => {
+    try {
+      await importing
+      throw new Error("that import was supposed to be refused")
+    } catch (error) {
+      return error.code
+    }
+  }
+
+  test("a file with nothing in it", async () => {
+    const manager = await managerWith(HEADER)
+
+    expect(await codeOf(manager.importCookies("   "))).toBe("COOKIES_FILE_EMPTY")
+  })
+
+  test("a jar yt-dlp will not open", async () => {
+    const manager = await managerWith(HEADER)
+
+    expect(
+      await codeOf(
+        manager.importCookies(
+          HEADER + ".youtube.com\tFALSE\t/\tTRUE\t1999999999\tLOGIN_INFO\tv\n"
+        )
+      )
+    ).toBe("COOKIES_MALFORMED")
+  })
+
+  test("a file with no cookies in it", async () => {
+    const manager = await managerWith(HEADER)
+
+    expect(await codeOf(manager.importCookies("milk\neggs\nbread\n"))).toBe(
+      "COOKIES_EMPTY"
+    )
+  })
+
+  test("a valid jar exported for some other site", async () => {
+    const manager = await managerWith(HEADER)
+
+    expect(
+      await codeOf(
+        manager.importCookies(
+          HEADER + cookieLine(".example.com", "session", live()) + "\n"
+        )
+      )
+    ).toBe("COOKIES_NOT_YOUTUBE")
+  })
+
+  test("a file too big to be a cookie export", async () => {
+    const manager = await managerWith(HEADER)
+    const huge = path.join(manager.cookieDir, "huge.txt")
+
+    await fs.writeFile(huge, "x".repeat(1024 * 1024 + 1), "utf8")
+
+    expect(await codeOf(manager.importCookieFile(huge))).toBe("COOKIES_TOO_BIG")
+  })
+
+  test("the json export several extensions offer", async () => {
+    const manager = await managerWith(HEADER)
+    const file = path.join(manager.cookieDir, "cookies.json")
+
+    await fs.writeFile(file, '[{"name": "SID", "domain": ".youtube.com"}]', "utf8")
+
+    expect(await codeOf(manager.importCookieFile(file))).toBe("COOKIES_JSON")
   })
 })


### PR DESCRIPTION
## Why

About 80% of active installs run with a Russian UI locale (PostHog, `app_launched` by `locale`, Aug–Sep 2026). The app was English only. This makes the main flows usable in Russian: paste a link, download, and import cookies when YouTube blocks the machine.

## What

- **No library.** Two typed dictionary files (`en.ts` is the source of truth, `ru.ts` is `Record<keyof typeof en, string>`, so a missing translation fails `tsc`), a 115-line runtime (`t()`, `useT()`, a zustand locale store), and a two-letter `en · ru` toggle beside the theme toggle. 247 keys.
- **Detection.** `navigator.language` starting with `ru` selects Russian. An explicit toggle choice is stored in `localStorage` and wins. `<html lang>` follows.
- **Design unchanged.** No new classes, colours, spacing, fonts or motion. Cyrillic renders in the OS fallback face where Space Grotesk has no glyphs; the mono voice already used the OS font.
- **English users see no text change**, apart from three typos that were never chosen copy ("video url URL", "1 cookies", "downlaods").
- **Main stays English.** Error wording and cookie-manager sentences keep feeding logs and GitHub issue bodies in English; the renderer swaps in Russian by error category and by a new stable `code` on each cookie sentence.
- **Native menu** and the message boxes it raises follow `app.getLocale()`. `createMenu()` now waits for `ready` so the locale is readable on fast machines.
- Out of scope on purpose: the about page, `PRIVACY.md`, the GitHub issue body, analytics values.

## Also in here

- The intermittent `tests/cookie-manager.test.js:417` failure is fixed in the test helper: the `CookieManager` constructor fires an un-awaited `initialize()`, which raced the import under test. Reproduced, then stubbed in a `beforeEach`. Five consecutive full runs green.

## Verification

| Check | Result |
| --- | --- |
| `npx vitest run` (renderer) | 235 passed, up from 181 |
| `npx jest` (main) | 1056 passed, up from 1021 |
| `tsc -b`, `eslint`, `vite build` | clean |
| Manual | Russian hero and cookie dialog compared against English at 1200×800, macOS; download card checked at the 379px `xl` column width |

Not verified here: Cyrillic on Windows, and the post-load screen inside the real Electron app on a second machine.

Design spec: `docs/superpowers/specs/2026-09-08-russian-localization-design.md`.
